### PR TITLE
[IA-1086] Reconcile shared Welder volume ownership/permissions

### DIFF
--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -122,8 +122,7 @@ object Settings {
       Some("us.gcr.io"),
       None,
       "broad-dsp-gcr-public/welder-server",
-      Some("rt-umask-test")
-      //git.gitHeadCommit.value.map(_.substring(0, 7))
+      git.gitHeadCommit.value.map(_.substring(0, 7))
     )
   )
 

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -104,7 +104,7 @@ object Settings {
       // Change the default umask for welder to support R/W access to the shared volume
       Cmd("USER", "root"),
       ExecCmd("RUN", "/bin/bash", "-c", s"echo '#!/bin/bash\\numask 002; /opt/docker/bin/server' > $entrypoint"),
-      Cmd("RUN", s"chown welder-user:users $entrypoint && chmod u+x,g+x $entrypoint"),
+      Cmd("RUN", s"chown -R welder-user:users /opt/docker && chmod u+x,g+x $entrypoint"),
       Cmd("USER", (daemonUser in Docker).value)
     )
   )

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -101,7 +101,7 @@ object Settings {
     dockerUpdateLatest := true,
     // See https://www.scala-sbt.org/sbt-native-packager/formats/docker.html#add-commands
     dockerCommands ++= List(
-      // Change the default umask for the system to support R/W access to the shared volume
+      // Change the default umask for welder to support R/W access to the shared volume
       Cmd("USER", "root"),
       ExecCmd("RUN", "/bin/bash", "-c", s"echo '#!/bin/bash\\numask 002; /opt/docker/bin/server' > $entrypoint"),
       Cmd("RUN", s"chown welder-user:users $entrypoint && chmod u+x,g+x $entrypoint"),
@@ -112,9 +112,9 @@ object Settings {
   lazy val serverDockerSettings = commonDockerSettings ++ List(
     mainClass in Compile := Some("org.broadinstitute.dsp.workbench.welder.server.Main"),
     packageName in Docker := "broad-dsp-gcr-public/welder-server",
+    // user, uid, group, and gid are all replicated in the Jupyter container
     daemonUser in Docker := "welder-user",
     daemonUserUid in Docker := Some("1001"),
-    // group and gid is consistent with the jupyter container
     daemonGroup in Docker := "users",
     daemonGroupGid in Docker := Some("100"),
     dockerEntrypoint := List(entrypoint),


### PR DESCRIPTION
Friends with: https://github.com/DataBiosphere/leonardo/pull/977
JIRA: https://broadworkbench.atlassian.net/browse/IA-1086

This PR essentially does 2 things:
1. Replaces the welder docker `ENTRYPOINT` with a new `entrypoint.sh` script which sets a umask prior to starting the welder server.
2. Configures welder to run as `welder-user:users`. This user/group is replicated in the Jupyter container, so welder-created files display as `welder-user`.

The result of this is that files/directories in the shared volume are always R/W to both containers. I verified this manually in both directions.