### PR TITLE
add flush api

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsp/workbench/welder/BackgroundTask.scala
+++ b/core/src/main/scala/org/broadinstitute/dsp/workbench/welder/BackgroundTask.scala
@@ -1,11 +1,13 @@
 package org.broadinstitute.dsp.workbench.welder
 
+import java.nio.file.Path
 import java.util.concurrent.TimeUnit
-
-import cats.effect.{IO, Timer}
+import cats.effect.{ContextShift, IO, Timer}
 import fs2.Stream
 import io.chrisdavenport.log4cats.Logger
+import JsonCodec._
 
+import scala.concurrent.ExecutionContext
 import scala.concurrent.duration.FiniteDuration
 
 object BackgroundTask {
@@ -27,5 +29,20 @@ object BackgroundTask {
     } yield ()).handleErrorWith(t => logger.error(t)("fail to update metadata cache"))
 
     (Stream.sleep[IO](interval) ++ Stream.eval(task)).repeat
+  }
+
+  def flushBothCache(interval: FiniteDuration,
+                      storageLinksPath: Path,
+                 metadataCachePath: Path,
+                 storageLinksCache: StorageLinksCache,
+                 metadataCache: MetadataCache,
+                 blockingEc: ExecutionContext)(implicit cs: ContextShift[IO], logger: Logger[IO], timer: Timer[IO]): Stream[IO, Unit] = {
+    val flushStorageLinks = flushCache(storageLinksPath, blockingEc, storageLinksCache).handleErrorWith { t =>
+      Stream.eval(logger.info(t)("failed to flush storagelinks cache to disk"))
+    }
+    val flushMetadataCache = flushCache(metadataCachePath, blockingEc, metadataCache).handleErrorWith { t =>
+      Stream.eval(logger.info(t)("failed to flush metadata cache to disk"))
+    }
+    (Stream.sleep[IO](interval) ++ flushStorageLinks ++ flushMetadataCache).repeat
   }
 }

--- a/core/src/main/scala/org/broadinstitute/dsp/workbench/welder/package.scala
+++ b/core/src/main/scala/org/broadinstitute/dsp/workbench/welder/package.scala
@@ -94,7 +94,8 @@ package object welder {
   val gcpObjectType = "text/plain"
 
   def cachedResource[A, B: Decoder: Encoder](path: Path, blockingEc: ExecutionContext, toTuple: B => List[(A, B)])(
-    implicit logger: Logger[IO], cs: ContextShift[IO]
+      implicit logger: Logger[IO],
+      cs: ContextShift[IO]
   ): Stream[IO, Ref[IO, Map[A, B]]] =
     for {
       cached <- readJsonFileToA[IO, List[B]](path).map(ls => ls.flatMap(b => toTuple(b)).toMap).handleErrorWith { error =>
@@ -102,18 +103,16 @@ package object welder {
       }
       ref <- Stream.resource(
         Resource.make(Ref.of[IO, Map[A, B]](cached))(
-          ref =>
-            flushCache(path, blockingEc, ref).compile.drain
+          ref => flushCache(path, blockingEc, ref).compile.drain
         )
       )
     } yield ref
 
-  def flushCache[A, B: Decoder: Encoder](path: Path, blockingEc: ExecutionContext, ref: Ref[IO, Map[A, B]])(implicit cs: ContextShift[IO]): Stream[IO, Unit] = {
+  def flushCache[A, B: Decoder: Encoder](path: Path, blockingEc: ExecutionContext, ref: Ref[IO, Map[A, B]])(implicit cs: ContextShift[IO]): Stream[IO, Unit] =
     Stream
       .eval(ref.get)
       .flatMap(x => Stream.emits(x.values.toSet.asJson.pretty(Printer.noSpaces).getBytes("UTF-8")))
       .through(fs2.io.file.writeAll[IO](path, blockingEc))
-  }
 
   implicit val eqLocalDirectory: Eq[LocalDirectory] = Eq.instance((p1, p2) => p1.path.toString == p2.path.toString)
   implicit def loggerToContextLogger[F[_]](logger: Logger[F]): ContextLogger[F] = ContextLogger(logger)

--- a/server/src/main/resources/api-docs.yaml
+++ b/server/src/main/resources/api-docs.yaml
@@ -25,7 +25,7 @@ paths:
           description: Internal Server Error
           schema:
             $ref: '#/definitions/ErrorReport'
-  '/lock':
+  '/objects/lock':
     post:
       summary: ''
       responses:

--- a/server/src/main/resources/api-docs.yaml
+++ b/server/src/main/resources/api-docs.yaml
@@ -15,6 +15,16 @@ produces:
 ## PATHS
 ##########################################################################################
 paths:
+  '/cache/flush':
+    post:
+      summary: 'flush in memory metadata and storagelinks cache to disk'
+      responses:
+        '204':
+          description: ''
+        '500':
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/ErrorReport'
   '/lock':
     post:
       summary: ''

--- a/server/src/main/resources/reference.conf
+++ b/server/src/main/resources/reference.conf
@@ -6,4 +6,5 @@ object-service {
   lock-expiration = 20 minutes
   owner-email = ${OWNER_EMAIL}
 }
-clean-up-lock-frequency = 7 minutes
+clean-up-lock-interval = 7 minutes
+flush-cache-interval = 10 minutes

--- a/server/src/main/scala/org/broadinstitute/dsp/workbench/welder/server/CacheService.scala
+++ b/server/src/main/scala/org/broadinstitute/dsp/workbench/welder/server/CacheService.scala
@@ -12,8 +12,9 @@ import org.http4s.dsl.Http4sDsl
 
 import scala.concurrent.ExecutionContext
 
-class CacheService(config: CachedServiceConfig, storageLinksCache: StorageLinksCache, metadataCache: MetadataCache, blockingEc: ExecutionContext)
-                  (implicit cs: ContextShift[IO]) extends Http4sDsl[IO] {
+class CacheService(config: CachedServiceConfig, storageLinksCache: StorageLinksCache, metadataCache: MetadataCache, blockingEc: ExecutionContext)(
+    implicit cs: ContextShift[IO]
+) extends Http4sDsl[IO] {
 
   val service: HttpRoutes[IO] = HttpRoutes.of[IO] {
     case POST -> Root / "flush" =>
@@ -28,8 +29,9 @@ class CacheService(config: CachedServiceConfig, storageLinksCache: StorageLinksC
 }
 
 object CacheService {
-  def apply(config: CachedServiceConfig, storageLinksCache: StorageLinksCache, metadataCache: MetadataCache, blockingEc: ExecutionContext)
-           (implicit cs: ContextShift[IO]): CacheService = new CacheService(config, storageLinksCache, metadataCache, blockingEc)
+  def apply(config: CachedServiceConfig, storageLinksCache: StorageLinksCache, metadataCache: MetadataCache, blockingEc: ExecutionContext)(
+      implicit cs: ContextShift[IO]
+  ): CacheService = new CacheService(config, storageLinksCache, metadataCache, blockingEc)
 }
 
 final case class CachedServiceConfig(storageLinksPath: Path, metadataCachePath: Path)

--- a/server/src/main/scala/org/broadinstitute/dsp/workbench/welder/server/CacheService.scala
+++ b/server/src/main/scala/org/broadinstitute/dsp/workbench/welder/server/CacheService.scala
@@ -1,0 +1,35 @@
+package org.broadinstitute.dsp.workbench.welder
+package server
+
+import java.nio.file.Path
+
+import cats.effect.{ContextShift, IO}
+import cats.implicits._
+import fs2.Stream
+import org.broadinstitute.dsp.workbench.welder.JsonCodec._
+import org.http4s.HttpRoutes
+import org.http4s.dsl.Http4sDsl
+
+import scala.concurrent.ExecutionContext
+
+class CacheService(config: CachedServiceConfig, storageLinksCache: StorageLinksCache, metadataCache: MetadataCache, blockingEc: ExecutionContext)
+                  (implicit cs: ContextShift[IO]) extends Http4sDsl[IO] {
+
+  val service: HttpRoutes[IO] = HttpRoutes.of[IO] {
+    case POST -> Root / "flush" =>
+      flush >> NoContent()
+  }
+
+  val flush: IO[Unit] = {
+    val flushStorageLinks = flushCache(config.storageLinksPath, blockingEc, storageLinksCache)
+    val flushMetadataCache = flushCache(config.metadataCachePath, blockingEc, metadataCache)
+    Stream(flushMetadataCache, flushStorageLinks).parJoin(2).compile.drain
+  }
+}
+
+object CacheService {
+  def apply(config: CachedServiceConfig, storageLinksCache: StorageLinksCache, metadataCache: MetadataCache, blockingEc: ExecutionContext)
+           (implicit cs: ContextShift[IO]): CacheService = new CacheService(config, storageLinksCache, metadataCache, blockingEc)
+}
+
+final case class CachedServiceConfig(storageLinksPath: Path, metadataCachePath: Path)

--- a/server/src/main/scala/org/broadinstitute/dsp/workbench/welder/server/Config.scala
+++ b/server/src/main/scala/org/broadinstitute/dsp/workbench/welder/server/Config.scala
@@ -29,7 +29,8 @@ object Config {
 
 final case class AppConfig(
     serverPort: Int,
-    cleanUpLockFrequency: FiniteDuration,
+    cleanUpLockInterval: FiniteDuration,
+    flushCacheInterval: FiniteDuration,
     pathToStorageLinksJson: Path,
     pathToGcsMetadataJson: Path,
     objectService: ObjectServiceConfig

--- a/server/src/main/scala/org/broadinstitute/dsp/workbench/welder/server/Main.scala
+++ b/server/src/main/scala/org/broadinstitute/dsp/workbench/welder/server/Main.scala
@@ -1,8 +1,6 @@
 package org.broadinstitute.dsp.workbench.welder
 package server
 
-import java.nio.file.Paths
-
 import cats.effect.{ExitCode, IO, IOApp}
 import cats.implicits._
 import fs2.Stream
@@ -25,33 +23,20 @@ object Main extends IOApp {
       implicit0(it: Linebacker[IO]) <- Stream.eval(Linebacker.bounded(Linebacker.fromExecutionContext[IO](blockingEc), 255))
       appConfig <- Stream.fromEither[IO](Config.appConfig)
       storageLinksCache <- cachedResource[RelativePath, StorageLink](
-        appConfig.pathToStorageLinksJson,
-        blockingEc,
-        storageLink => List(storageLink.localBaseDirectory.path -> storageLink, storageLink.localSafeModeBaseDirectory.path -> storageLink)
+                       appConfig.pathToStorageLinksJson,
+                       blockingEc,
+                       storageLink => List(storageLink.localBaseDirectory.path -> storageLink, storageLink.localSafeModeBaseDirectory.path -> storageLink)
       )
       metadataCache <- cachedResource[RelativePath, AdaptedGcsMetadataCache](
-        appConfig.pathToGcsMetadataJson,
-        blockingEc,
-        metadata => List(metadata.localPath -> metadata)
+                       appConfig.pathToGcsMetadataJson,
+                       blockingEc,
+                       metadata => List(metadata.localPath -> metadata)
       )
-      googleStorageService <- Stream.resource(GoogleStorageService.fromApplicationDefault())
-      storageLinksService = StorageLinksService(storageLinksCache)
-      googleStorageAlg = GoogleStorageAlg.fromGoogle(GoogleStorageAlgConfig(appConfig.objectService.workingDirectory), googleStorageService)
-      storageLinkAlg = StorageLinksAlg.fromCache(storageLinksCache)
-      objectService = ObjectService(appConfig.objectService, googleStorageAlg, blockingEc, storageLinkAlg, metadataCache)
-      serverStream = BlazeServerBuilder[IO].bindHttp(appConfig.serverPort, "0.0.0.0").withHttpApp(WelderApp(objectService, storageLinksService).service).serve
+      welderApp <- initWelderApp(appConfig, blockingEc, storageLinksCache, metadataCache)
+      serverStream = BlazeServerBuilder[IO].bindHttp(appConfig.serverPort, "0.0.0.0").withHttpApp(welderApp.service).serve
       cleanUpCache = BackgroundTask.cleanUpLock(metadataCache, appConfig.cleanUpLockFrequency)
       _ <- Stream(cleanUpCache, serverStream.drain).covary[IO].parJoin(2)
     } yield ()
-
-    sys.addShutdownHook(
-      Stream
-        .emits("this is weird".getBytes("UTF-8")).covary[IO]
-        .through(fs2.io.file.writeAll(Paths.get("/work/qiTest"), scala.concurrent.ExecutionContext.global))
-        .compile
-        .drain
-        .unsafeRunSync()
-    )
 
     app
       .handleErrorWith { error =>
@@ -60,5 +45,22 @@ object Main extends IOApp {
       .compile
       .drain
       .as(ExitCode.Success)
+  }
+
+  def initWelderApp(appConfig: AppConfig, blockingEc: ExecutionContext, storageLinksCache: StorageLinksCache, metadataCache: MetadataCache)(implicit logger: Logger[IO]): Stream[IO, WelderApp] = for {
+    implicit0(it: Linebacker[IO]) <- Stream.eval(Linebacker.bounded(Linebacker.fromExecutionContext[IO](blockingEc), 255))
+    googleStorageService <- Stream.resource(GoogleStorageService.fromApplicationDefault())
+  } yield {
+    val storageLinksService = StorageLinksService(storageLinksCache)
+    val googleStorageAlg = GoogleStorageAlg.fromGoogle(GoogleStorageAlgConfig(appConfig.objectService.workingDirectory), googleStorageService)
+    val storageLinkAlg = StorageLinksAlg.fromCache(storageLinksCache)
+    val objectService = ObjectService(appConfig.objectService, googleStorageAlg, blockingEc, storageLinkAlg, metadataCache)
+    val cacheService = CacheService(
+      CachedServiceConfig(appConfig.pathToStorageLinksJson, appConfig.pathToGcsMetadataJson),
+      storageLinksCache,
+      metadataCache,
+      blockingEc
+    )
+    WelderApp(objectService, storageLinksService, cacheService)
   }
 }

--- a/server/src/main/scala/org/broadinstitute/dsp/workbench/welder/server/Main.scala
+++ b/server/src/main/scala/org/broadinstitute/dsp/workbench/welder/server/Main.scala
@@ -23,14 +23,14 @@ object Main extends IOApp {
       implicit0(it: Linebacker[IO]) <- Stream.eval(Linebacker.bounded(Linebacker.fromExecutionContext[IO](blockingEc), 255))
       appConfig <- Stream.fromEither[IO](Config.appConfig)
       storageLinksCache <- cachedResource[RelativePath, StorageLink](
-                       appConfig.pathToStorageLinksJson,
-                       blockingEc,
-                       storageLink => List(storageLink.localBaseDirectory.path -> storageLink, storageLink.localSafeModeBaseDirectory.path -> storageLink)
+        appConfig.pathToStorageLinksJson,
+        blockingEc,
+        storageLink => List(storageLink.localBaseDirectory.path -> storageLink, storageLink.localSafeModeBaseDirectory.path -> storageLink)
       )
       metadataCache <- cachedResource[RelativePath, AdaptedGcsMetadataCache](
-                       appConfig.pathToGcsMetadataJson,
-                       blockingEc,
-                       metadata => List(metadata.localPath -> metadata)
+        appConfig.pathToGcsMetadataJson,
+        blockingEc,
+        metadata => List(metadata.localPath -> metadata)
       )
       welderApp <- initWelderApp(appConfig, blockingEc, storageLinksCache, metadataCache)
       serverStream = BlazeServerBuilder[IO].bindHttp(appConfig.serverPort, "0.0.0.0").withHttpApp(welderApp.service).serve
@@ -47,20 +47,23 @@ object Main extends IOApp {
       .as(ExitCode.Success)
   }
 
-  def initWelderApp(appConfig: AppConfig, blockingEc: ExecutionContext, storageLinksCache: StorageLinksCache, metadataCache: MetadataCache)(implicit logger: Logger[IO]): Stream[IO, WelderApp] = for {
-    implicit0(it: Linebacker[IO]) <- Stream.eval(Linebacker.bounded(Linebacker.fromExecutionContext[IO](blockingEc), 255))
-    googleStorageService <- Stream.resource(GoogleStorageService.fromApplicationDefault())
-  } yield {
-    val storageLinksService = StorageLinksService(storageLinksCache)
-    val googleStorageAlg = GoogleStorageAlg.fromGoogle(GoogleStorageAlgConfig(appConfig.objectService.workingDirectory), googleStorageService)
-    val storageLinkAlg = StorageLinksAlg.fromCache(storageLinksCache)
-    val objectService = ObjectService(appConfig.objectService, googleStorageAlg, blockingEc, storageLinkAlg, metadataCache)
-    val cacheService = CacheService(
-      CachedServiceConfig(appConfig.pathToStorageLinksJson, appConfig.pathToGcsMetadataJson),
-      storageLinksCache,
-      metadataCache,
-      blockingEc
-    )
-    WelderApp(objectService, storageLinksService, cacheService)
-  }
+  def initWelderApp(appConfig: AppConfig, blockingEc: ExecutionContext, storageLinksCache: StorageLinksCache, metadataCache: MetadataCache)(
+      implicit logger: Logger[IO]
+  ): Stream[IO, WelderApp] =
+    for {
+      implicit0(it: Linebacker[IO]) <- Stream.eval(Linebacker.bounded(Linebacker.fromExecutionContext[IO](blockingEc), 255))
+      googleStorageService <- Stream.resource(GoogleStorageService.fromApplicationDefault())
+    } yield {
+      val storageLinksService = StorageLinksService(storageLinksCache)
+      val googleStorageAlg = GoogleStorageAlg.fromGoogle(GoogleStorageAlgConfig(appConfig.objectService.workingDirectory), googleStorageService)
+      val storageLinkAlg = StorageLinksAlg.fromCache(storageLinksCache)
+      val objectService = ObjectService(appConfig.objectService, googleStorageAlg, blockingEc, storageLinkAlg, metadataCache)
+      val cacheService = CacheService(
+        CachedServiceConfig(appConfig.pathToStorageLinksJson, appConfig.pathToGcsMetadataJson),
+        storageLinksCache,
+        metadataCache,
+        blockingEc
+      )
+      WelderApp(objectService, storageLinksService, cacheService)
+    }
 }

--- a/server/src/main/scala/org/broadinstitute/dsp/workbench/welder/server/StorageLinksService.scala
+++ b/server/src/main/scala/org/broadinstitute/dsp/workbench/welder/server/StorageLinksService.scala
@@ -22,7 +22,7 @@ class StorageLinksService(storageLinks: StorageLinksCache) extends Http4sDsl[IO]
       for {
         storageLink <- req.as[StorageLink]
         _ <- deleteStorageLink(storageLink)
-        resp <- Ok(())
+        resp <- NoContent()
       } yield resp
     case req @ POST -> Root =>
       for {

--- a/server/src/main/scala/org/broadinstitute/dsp/workbench/welder/server/WelderApp.scala
+++ b/server/src/main/scala/org/broadinstitute/dsp/workbench/welder/server/WelderApp.scala
@@ -11,11 +11,12 @@ import org.http4s.server.middleware.Logger
 import org.http4s.syntax.kleisli._
 import org.http4s.{HttpApp, Response}
 
-class WelderApp(objectService: ObjectService, storageLinksService: StorageLinksService)(implicit cs: ContextShift[IO]) extends Http4sDsl[IO] {
+class WelderApp(objectService: ObjectService, storageLinksService: StorageLinksService, cacheService: CacheService)(implicit cs: ContextShift[IO]) extends Http4sDsl[IO] {
   private val routes: HttpApp[IO] = Router[IO](
     "/status" -> StatusService.service,
     "/storageLinks" -> storageLinksService.service,
-    "/objects" -> objectService.service
+    "/objects" -> objectService.service,
+    "/cache" -> cacheService.service
   ).orNotFound
 
   val errorHandler: IO[Response[IO]] => IO[Response[IO]] = response => {
@@ -39,8 +40,8 @@ class WelderApp(objectService: ObjectService, storageLinksService: StorageLinksS
 }
 
 object WelderApp {
-  def apply(syncService: ObjectService, storageLinksService: StorageLinksService)(implicit cs: ContextShift[IO]): WelderApp =
-    new WelderApp(syncService, storageLinksService)
+  def apply(syncService: ObjectService, storageLinksService: StorageLinksService, cacheService: CacheService)(implicit cs: ContextShift[IO]): WelderApp =
+    new WelderApp(syncService, storageLinksService, cacheService)
 
   implicit val errorReportEncoder: Encoder[ErrorReport] = Encoder.forProduct2("errorMessage", "errorCode")(x => ErrorReport.unapply(x).get)
 }

--- a/server/src/main/scala/org/broadinstitute/dsp/workbench/welder/server/WelderApp.scala
+++ b/server/src/main/scala/org/broadinstitute/dsp/workbench/welder/server/WelderApp.scala
@@ -11,7 +11,8 @@ import org.http4s.server.middleware.Logger
 import org.http4s.syntax.kleisli._
 import org.http4s.{HttpApp, Response}
 
-class WelderApp(objectService: ObjectService, storageLinksService: StorageLinksService, cacheService: CacheService)(implicit cs: ContextShift[IO]) extends Http4sDsl[IO] {
+class WelderApp(objectService: ObjectService, storageLinksService: StorageLinksService, cacheService: CacheService)(implicit cs: ContextShift[IO])
+    extends Http4sDsl[IO] {
   private val routes: HttpApp[IO] = Router[IO](
     "/status" -> StatusService.service,
     "/storageLinks" -> storageLinksService.service,

--- a/server/src/test/scala/org/broadinstitute/dsp/workbench/welder/server/CacheServiceSpec.scala
+++ b/server/src/test/scala/org/broadinstitute/dsp/workbench/welder/server/CacheServiceSpec.scala
@@ -42,7 +42,6 @@ class CacheServiceSpec extends FlatSpec with Matchers with WelderTestSuite {
         }
       res.unsafeRunSync()
     }
-
   }
 }
 

--- a/server/src/test/scala/org/broadinstitute/dsp/workbench/welder/server/CacheServiceSpec.scala
+++ b/server/src/test/scala/org/broadinstitute/dsp/workbench/welder/server/CacheServiceSpec.scala
@@ -1,0 +1,49 @@
+package org.broadinstitute.dsp.workbench.welder
+package server
+
+import java.io.File
+import java.nio.file.Paths
+
+import cats.effect.IO
+import cats.effect.concurrent.Ref
+import org.broadinstitute.dsp.workbench.welder.Generators._
+import org.broadinstitute.dsp.workbench.welder.JsonCodec._
+import org.http4s.{Method, Request, Status, Uri}
+import org.scalatest.{FlatSpec, Matchers}
+
+import scala.concurrent.ExecutionContext.global
+
+class CacheServiceSpec extends FlatSpec with Matchers with WelderTestSuite {
+  val config = CachedServiceConfig(Paths.get("/tmp/storagelinks.json"), Paths.get("/tmp/metadata.json"))
+
+
+  "CacheService" should "return service status" in {
+    forAll {
+      (localPath: RelativePath, storageLink: StorageLink) =>
+        val metadata = AdaptedGcsMetadataCache(localPath, None, None)
+        val cacheService = CacheService (
+          config,
+          Ref.unsafe[IO, Map[RelativePath, StorageLink]](Map(localPath -> storageLink)),
+          Ref.unsafe[IO, Map[RelativePath, AdaptedGcsMetadataCache]](Map(localPath -> metadata)),
+          global
+        )
+        val request = Request[IO](method = Method.POST, uri = Uri.unsafeFromString("/flush"))
+
+        val res = for {
+          resp <- cacheService.service.run(request).value
+          storageLinkResult <- readJsonFileToA[IO, List[StorageLink]](config.storageLinksPath).compile.lastOrError
+          metadataResult <- readJsonFileToA[IO, List[AdaptedGcsMetadataCache]](config.metadataCachePath).compile.lastOrError
+          _ <- IO((new File(config.storageLinksPath.toString)).delete())
+          _ <- IO((new File(config.metadataCachePath.toString)).delete())
+        } yield {
+          resp.get.status shouldBe Status.NoContent
+          storageLinkResult shouldBe(List(storageLink))
+          metadataResult shouldBe(List(metadata))
+        }
+      res.unsafeRunSync()
+    }
+
+  }
+}
+
+

--- a/server/src/test/scala/org/broadinstitute/dsp/workbench/welder/server/ConfigSpec.scala
+++ b/server/src/test/scala/org/broadinstitute/dsp/workbench/welder/server/ConfigSpec.scala
@@ -11,7 +11,7 @@ class ConfigSpec extends FlatSpec with Matchers {
   "Config" should "read configuration correctly" in {
     val config = Config.appConfig
     val objectServiceConfig = ObjectServiceConfig(Paths.get("/work"), WorkbenchEmail("fake@gmail.com"), 20 minutes)
-    val expectedConfig = AppConfig(8080, 7 minutes, Paths.get("/work/storage_links.json"), Paths.get("/work/gcs_metadata.json"), objectServiceConfig)
+    val expectedConfig = AppConfig(8080, 7 minutes, 10 minutes, Paths.get("/work/storage_links.json"), Paths.get("/work/gcs_metadata.json"), objectServiceConfig)
     config shouldBe Right(expectedConfig)
   }
 }


### PR DESCRIPTION
when cluster gets shut down, jvm shutdown hook doesn't seem to get executed. Add an API for explicitly flushing cache to disk