### PR TITLE
fix a bug when gs path only has bucket name

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsp/workbench/welder/model.scala
+++ b/core/src/main/scala/org/broadinstitute/dsp/workbench/welder/model.scala
@@ -59,7 +59,7 @@ object LocalDirectory {
   final case class LocalSafeBaseDirectory(path: RelativePath) extends LocalDirectory
 }
 
-final case class CloudStorageDirectory(bucketName: GcsBucketName, blobPath: BlobPath)
+final case class CloudStorageDirectory(bucketName: GcsBucketName, blobPath: Option[BlobPath])
 
 final case class StorageLink(
     localBaseDirectory: LocalDirectory,

--- a/core/src/main/scala/org/broadinstitute/dsp/workbench/welder/package.scala
+++ b/core/src/main/scala/org/broadinstitute/dsp/workbench/welder/package.scala
@@ -63,9 +63,12 @@ package object welder {
       )
       .toList
 
-  def getFullBlobName(basePath: RelativePath, localPath: Path, blobPath: BlobPath): GcsBlobName = {
+  def getFullBlobName(basePath: RelativePath, localPath: Path, blobPath: Option[BlobPath]): GcsBlobName = {
     val subPath = basePath.asPath.relativize(localPath)
-    GcsBlobName(blobPath.asString + "/" + subPath.toString)
+    blobPath match {
+      case Some(bp) => GcsBlobName(bp.asString + "/" + subPath.toString)
+      case None => GcsBlobName(subPath.toString)
+    }
   }
 
   val base64Decoder = Base64.getDecoder()

--- a/core/src/test/scala/org/broadinstitute/dsp/workbench/welder/Generators.scala
+++ b/core/src/test/scala/org/broadinstitute/dsp/workbench/welder/Generators.scala
@@ -40,8 +40,9 @@ object Generators {
 
   val genCloudStorageDirectory = for {
     bucketName <- google2.Generators.genGcsBucketName
-    blobPath <- Gen.uuid.map(x => BlobPath(x.toString))
-  } yield CloudStorageDirectory(bucketName, blobPath)
+    blobPath = Gen.uuid.map(x => BlobPath(x.toString))
+    blobPathOpt <- Gen.option[BlobPath](blobPath)
+  } yield CloudStorageDirectory(bucketName, blobPathOpt)
 
   val genStorageLink = for {
     localBaseDirectory <- genLocalBaseDirectory

--- a/core/src/test/scala/org/broadinstitute/dsp/workbench/welder/JsonCodecSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsp/workbench/welder/JsonCodecSpec.scala
@@ -14,7 +14,7 @@ class JsonCodecSpec extends FlatSpec with ScalaCheckPropertyChecks with WelderTe
         val inputString = s"gs://${bucketName.value}/notebooks/sub"
 
         val res = Json.fromString(inputString).as[CloudStorageDirectory]
-        res shouldBe(Right(CloudStorageDirectory(bucketName, BlobPath("notebooks/sub"))))
+        res shouldBe(Right(CloudStorageDirectory(bucketName, Some(BlobPath("notebooks/sub")))))
     }
   }
 
@@ -24,7 +24,7 @@ class JsonCodecSpec extends FlatSpec with ScalaCheckPropertyChecks with WelderTe
         val inputString = s"gs://${bucketName.value}"
 
         val res = Json.fromString(inputString).as[CloudStorageDirectory]
-        res shouldBe(Right(CloudStorageDirectory(bucketName, BlobPath(""))))
+        res shouldBe(Right(CloudStorageDirectory(bucketName, None)))
     }
   }
 }

--- a/core/src/test/scala/org/broadinstitute/dsp/workbench/welder/PackageSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsp/workbench/welder/PackageSpec.scala
@@ -37,7 +37,13 @@ class PackageSpec extends FlatSpec with ScalaCheckPropertyChecks with WelderTest
     val localPath = Paths.get("workspaces/ws1/sub/notebook1.ipynb")
     getPossibleBaseDirectory(localPath).map(_.toString) shouldBe(List("workspaces/ws1/sub", "workspaces/ws1", "workspaces"))
     val basePath = RelativePath(Paths.get("workspaces/ws1"))
-    getFullBlobName(basePath, localPath, BlobPath("notebooks")) shouldBe(GcsBlobName("notebooks/sub/notebook1.ipynb"))
+    getFullBlobName(basePath, localPath, Some(BlobPath("notebooks"))) shouldBe(GcsBlobName("notebooks/sub/notebook1.ipynb"))
+  }
+
+  it should "parse path correctly when blobPath doesn't exist" in {
+    val localPath = Paths.get("workspaces/ws1/sub/notebook1.ipynb")
+    val basePath = RelativePath(Paths.get("workspaces/ws1"))
+    getFullBlobName(basePath, localPath, None) shouldBe(GcsBlobName("sub/notebook1.ipynb"))
   }
 
   "hashMetadata" should "consistently hash a string" in {

--- a/server/src/test/scala/org/broadinstitute/dsp/workbench/welder/server/ObjectServiceSpec.scala
+++ b/server/src/test/scala/org/broadinstitute/dsp/workbench/welder/server/ObjectServiceSpec.scala
@@ -135,7 +135,8 @@ class ObjectServiceSpec extends FlatSpec with WelderTestSuite {
                              |}""".stripMargin
         val requestBodyJson = parser.parse(requestBody).getOrElse(throw new Exception(s"invalid request body $requestBody"))
         val request = Request[IO](method = Method.POST, uri = Uri.unsafeFromString("/metadata")).withEntity[Json](requestBodyJson)
-        val expectedBody = s"""{"syncMode":"EDIT","syncStatus":"REMOTE_NOT_FOUND","storageLink":{"localBaseDirectory":"${localBaseDirectory.path.toString}","localSafeModeBaseDirectory":"${localSafeDirectory.path.toString}","cloudStorageDirectory":"gs://${cloudStorageDirectory.bucketName}/${cloudStorageDirectory.blobPath.asString}","pattern":"*.ipynb"}}"""
+        val expectedBlobPath = cloudStorageDirectory.blobPath.fold("")(s => s"/${s.asString}")
+        val expectedBody = s"""{"syncMode":"EDIT","syncStatus":"REMOTE_NOT_FOUND","storageLink":{"localBaseDirectory":"${localBaseDirectory.path.toString}","localSafeModeBaseDirectory":"${localSafeDirectory.path.toString}","cloudStorageDirectory":"gs://${cloudStorageDirectory.bucketName}${expectedBlobPath}","pattern":"*.ipynb"}}"""
         val res = for {
           resp <- objectService.service.run(request).value
           body <- resp.get.body.through(text.utf8Decode).compile.foldMonoid
@@ -160,7 +161,8 @@ class ObjectServiceSpec extends FlatSpec with WelderTestSuite {
              |}""".stripMargin
         val requestBodyJson = parser.parse(requestBody).getOrElse(throw new Exception(s"invalid request body $requestBody"))
         val request = Request[IO](method = Method.POST, uri = Uri.unsafeFromString("/metadata")).withEntity[Json](requestBodyJson)
-        val expectedBody = s"""{"syncMode":"SAFE","storageLink":{"localBaseDirectory":"${localBaseDirectory.path.toString}","localSafeModeBaseDirectory":"${localSafeDirectory.path.toString}","cloudStorageDirectory":"gs://${cloudStorageDirectory.bucketName}/${cloudStorageDirectory.blobPath.asString}","pattern":"*.ipynb"}}"""
+        val expectedBlobPath = cloudStorageDirectory.blobPath.fold("")(s => s"/${s.asString}")
+        val expectedBody = s"""{"syncMode":"SAFE","storageLink":{"localBaseDirectory":"${localBaseDirectory.path.toString}","localSafeModeBaseDirectory":"${localSafeDirectory.path.toString}","cloudStorageDirectory":"gs://${cloudStorageDirectory.bucketName}${expectedBlobPath}","pattern":"*.ipynb"}}"""
         val res = for {
           resp <- objectService.service.run(request).value
           body <- resp.get.body.through(text.utf8Decode).compile.foldMonoid
@@ -189,7 +191,8 @@ class ObjectServiceSpec extends FlatSpec with WelderTestSuite {
                              |}""".stripMargin
         val requestBodyJson = parser.parse(requestBody).getOrElse(throw new Exception(s"invalid request body $requestBody"))
         val request = Request[IO](method = Method.POST, uri = Uri.unsafeFromString("/metadata")).withEntity[Json](requestBodyJson)
-        val expectedBody = s"""{"syncMode":"EDIT","syncStatus":"LIVE","lastLockedBy":null,"storageLink":{"localBaseDirectory":"${localBaseDirectory.path.toString}","localSafeModeBaseDirectory":"${localSafeDirectory.path.toString}","cloudStorageDirectory":"gs://${cloudStorageDirectory.bucketName}/${cloudStorageDirectory.blobPath.asString}","pattern":"*.ipynb"}}"""
+        val expectedBlobPath = cloudStorageDirectory.blobPath.fold("")(s => s"/${s.asString}")
+        val expectedBody = s"""{"syncMode":"EDIT","syncStatus":"LIVE","lastLockedBy":null,"storageLink":{"localBaseDirectory":"${localBaseDirectory.path.toString}","localSafeModeBaseDirectory":"${localSafeDirectory.path.toString}","cloudStorageDirectory":"gs://${cloudStorageDirectory.bucketName}${expectedBlobPath}","pattern":"*.ipynb"}}"""
         // Create the local base directory
         val directory = new File(s"/tmp/${localBaseDirectory.path.toString}")
         if (!directory.exists) {
@@ -230,7 +233,8 @@ class ObjectServiceSpec extends FlatSpec with WelderTestSuite {
                              |}""".stripMargin
         val requestBodyJson = parser.parse(requestBody).getOrElse(throw new Exception(s"invalid request body $requestBody"))
         val request = Request[IO](method = Method.POST, uri = Uri.unsafeFromString("/metadata")).withEntity[Json](requestBodyJson)
-        val expectedBody = s"""{"syncMode":"EDIT","syncStatus":"LOCAL_CHANGED","lastLockedBy":null,"storageLink":{"localBaseDirectory":"${localBaseDirectory.path.toString}","localSafeModeBaseDirectory":"${localSafeDirectory.path.toString}","cloudStorageDirectory":"gs://${cloudStorageDirectory.bucketName}/${cloudStorageDirectory.blobPath.asString}","pattern":"*.ipynb"}}"""
+        val expectedBlobPath = cloudStorageDirectory.blobPath.fold("")(s => s"/${s.asString}")
+        val expectedBody = s"""{"syncMode":"EDIT","syncStatus":"LOCAL_CHANGED","lastLockedBy":null,"storageLink":{"localBaseDirectory":"${localBaseDirectory.path.toString}","localSafeModeBaseDirectory":"${localSafeDirectory.path.toString}","cloudStorageDirectory":"gs://${cloudStorageDirectory.bucketName}${expectedBlobPath}","pattern":"*.ipynb"}}"""
         // Create the local base directory
         val directory = new File(s"/tmp/${localBaseDirectory.path.toString}")
         if (!directory.exists) {
@@ -268,7 +272,8 @@ class ObjectServiceSpec extends FlatSpec with WelderTestSuite {
                              |}""".stripMargin
         val requestBodyJson = parser.parse(requestBody).getOrElse(throw new Exception(s"invalid request body $requestBody"))
         val request = Request[IO](method = Method.POST, uri = Uri.unsafeFromString("/metadata")).withEntity[Json](requestBodyJson)
-        val expectedBody = s"""{"syncMode":"EDIT","syncStatus":"REMOTE_CHANGED","lastLockedBy":null,"storageLink":{"localBaseDirectory":"${localBaseDirectory.path.toString}","localSafeModeBaseDirectory":"${localSafeDirectory.path.toString}","cloudStorageDirectory":"gs://${cloudStorageDirectory.bucketName}/${cloudStorageDirectory.blobPath.asString}","pattern":"*.ipynb"}}"""
+        val expectedBlobPath = cloudStorageDirectory.blobPath.fold("")(s => s"/${s.asString}")
+        val expectedBody = s"""{"syncMode":"EDIT","syncStatus":"REMOTE_CHANGED","lastLockedBy":null,"storageLink":{"localBaseDirectory":"${localBaseDirectory.path.toString}","localSafeModeBaseDirectory":"${localSafeDirectory.path.toString}","cloudStorageDirectory":"gs://${cloudStorageDirectory.bucketName}${expectedBlobPath}","pattern":"*.ipynb"}}"""
         // Create the local base directory
         val directory = new File(s"/tmp/${localBaseDirectory.path.toString}")
         if (!directory.exists) {
@@ -303,7 +308,8 @@ class ObjectServiceSpec extends FlatSpec with WelderTestSuite {
                              |}""".stripMargin
         val requestBodyJson = parser.parse(requestBody).getOrElse(throw new Exception(s"invalid request body $requestBody"))
         val request = Request[IO](method = Method.POST, uri = Uri.unsafeFromString("/metadata")).withEntity[Json](requestBodyJson)
-        val expectedBody = s"""{"syncMode":"EDIT","syncStatus":"DESYNCHRONIZED","lastLockedBy":null,"storageLink":{"localBaseDirectory":"${localBaseDirectory.path.toString}","localSafeModeBaseDirectory":"${localSafeDirectory.path.toString}","cloudStorageDirectory":"gs://${cloudStorageDirectory.bucketName}/${cloudStorageDirectory.blobPath.asString}","pattern":"*.ipynb"}}"""
+        val expectedBlobPath = cloudStorageDirectory.blobPath.fold("")(s => s"/${s.asString}")
+        val expectedBody = s"""{"syncMode":"EDIT","syncStatus":"DESYNCHRONIZED","lastLockedBy":null,"storageLink":{"localBaseDirectory":"${localBaseDirectory.path.toString}","localSafeModeBaseDirectory":"${localSafeDirectory.path.toString}","cloudStorageDirectory":"gs://${cloudStorageDirectory.bucketName}${expectedBlobPath}","pattern":"*.ipynb"}}"""
         // Create the local base directory
         val directory = new File(s"/tmp/${localBaseDirectory.path.toString}")
         if (!directory.exists) {
@@ -338,7 +344,8 @@ class ObjectServiceSpec extends FlatSpec with WelderTestSuite {
                              |}""".stripMargin
         val requestBodyJson = parser.parse(requestBody).getOrElse(throw new Exception(s"invalid request body $requestBody"))
         val request = Request[IO](method = Method.POST, uri = Uri.unsafeFromString("/metadata")).withEntity[Json](requestBodyJson)
-        val expectedBody = s"""{"syncMode":"EDIT","syncStatus":"LIVE","lastLockedBy":"${lockedBy.value}","storageLink":{"localBaseDirectory":"${localBaseDirectory.path.toString}","localSafeModeBaseDirectory":"${localSafeDirectory.path.toString}","cloudStorageDirectory":"gs://${cloudStorageDirectory.bucketName}/${cloudStorageDirectory.blobPath.asString}","pattern":"*.ipynb"}}"""
+        val expectedBlobPath = cloudStorageDirectory.blobPath.fold("")(s => s"/${s.asString}")
+        val expectedBody = s"""{"syncMode":"EDIT","syncStatus":"LIVE","lastLockedBy":"${lockedBy.value}","storageLink":{"localBaseDirectory":"${localBaseDirectory.path.toString}","localSafeModeBaseDirectory":"${localSafeDirectory.path.toString}","cloudStorageDirectory":"gs://${cloudStorageDirectory.bucketName}${expectedBlobPath}","pattern":"*.ipynb"}}"""
         // Create the local base directory
         val directory = new File(s"/tmp/${localBaseDirectory.path.toString}")
         if (!directory.exists) {
@@ -372,7 +379,8 @@ class ObjectServiceSpec extends FlatSpec with WelderTestSuite {
                              |}""".stripMargin
         val requestBodyJson = parser.parse(requestBody).getOrElse(throw new Exception(s"invalid request body $requestBody"))
         val request = Request[IO](method = Method.POST, uri = Uri.unsafeFromString("/metadata")).withEntity[Json](requestBodyJson)
-        val expectedBody = s"""{"syncMode":"EDIT","syncStatus":"LIVE","lastLockedBy":null,"storageLink":{"localBaseDirectory":"${localBaseDirectory.path.toString}","localSafeModeBaseDirectory":"${localSafeDirectory.path.toString}","cloudStorageDirectory":"gs://${cloudStorageDirectory.bucketName}/${cloudStorageDirectory.blobPath.asString}","pattern":"*.ipynb"}}"""
+        val expectedBlobPath = cloudStorageDirectory.blobPath.fold("")(s => s"/${s.asString}")
+        val expectedBody = s"""{"syncMode":"EDIT","syncStatus":"LIVE","lastLockedBy":null,"storageLink":{"localBaseDirectory":"${localBaseDirectory.path.toString}","localSafeModeBaseDirectory":"${localSafeDirectory.path.toString}","cloudStorageDirectory":"gs://${cloudStorageDirectory.bucketName}${expectedBlobPath}","pattern":"*.ipynb"}}"""
         // Create the local base directory
         val directory = new File(s"/tmp/${localBaseDirectory.path.toString}")
         if (!directory.exists) {

--- a/server/src/test/scala/org/broadinstitute/dsp/workbench/welder/server/StorageLinksApiServiceSpec.scala
+++ b/server/src/test/scala/org/broadinstitute/dsp/workbench/welder/server/StorageLinksApiServiceSpec.scala
@@ -17,7 +17,7 @@ import org.scalatest.FlatSpec
 class StorageLinksApiServiceSpec extends FlatSpec with WelderTestSuite {
   val storageLinks = Ref.unsafe[IO, Map[RelativePath, StorageLink]](Map.empty)
   val storageLinksService = StorageLinksService(storageLinks)
-  val cloudStorageDirectory = CloudStorageDirectory(GcsBucketName("foo"), BlobPath("bar"))
+  val cloudStorageDirectory = CloudStorageDirectory(GcsBucketName("foo"), Some(BlobPath("bar")))
   val baseDir = RelativePath(Paths.get("foo"))
   val baseSafeDir = RelativePath(Paths.get("bar"))
 

--- a/server/src/test/scala/org/broadinstitute/dsp/workbench/welder/server/StorageLinksServiceSpec.scala
+++ b/server/src/test/scala/org/broadinstitute/dsp/workbench/welder/server/StorageLinksServiceSpec.scala
@@ -13,7 +13,7 @@ import org.scalatest.{FlatSpec, Matchers}
 
 class StorageLinksServiceSpec extends FlatSpec with Matchers {
   implicit val unsafeLogger: Logger[IO] = Slf4jLogger.getLogger[IO]
-  val cloudStorageDirectory = CloudStorageDirectory(GcsBucketName("foo"), BlobPath("bar/baz.zip"))
+  val cloudStorageDirectory = CloudStorageDirectory(GcsBucketName("foo"), Some(BlobPath("bar/baz.zip")))
   val baseDir = LocalBaseDirectory(RelativePath(Paths.get("/foo")))
   val baseSafeDir = LocalSafeBaseDirectory(RelativePath(Paths.get("/bar")))
 


### PR DESCRIPTION
When Gs path only has bucket name, there's a bug where the blobPath is prepended with `/` wrongly.

Tested locally

```
curl -vX POST --header 'Content-Type: application/json' --header 'Accept: application/json' localhost:8080/objects/metadata -d '{"localPath": "edit/welder-test_nb.ipynb" }'

Note: Unnecessary use of -X or --request, POST is already inferred.
*   Trying ::1...
* TCP_NODELAY set
* Connected to localhost (::1) port 8080 (#0)
> POST /objects/metadata HTTP/1.1
> Host: localhost:8080
> User-Agent: curl/7.54.0
> Content-Type: application/json
> Accept: application/json
> Content-Length: 43
>
* upload completely sent off: 43 out of 43 bytes
< HTTP/1.1 200 OK
< Content-Type: application/json
< Date: Wed, 03 Jul 2019 17:43:44 GMT
< Content-Length: 192
<
* Connection #0 to host localhost left intact
{"syncMode":"EDIT","syncStatus":"LIVE","lastLockedBy":null,"storageLink":{"localBaseDirectory":"edit","localSafeModeBaseDirectory":"safe","cloudStorageDirectory":"gs://qi-test","pattern":"*"}}%
```