### PR TITLE
IA-1155 IA-1150 

### DIFF
--- a/server/src/main/scala/org/broadinstitute/dsp/workbench/welder/server/ObjectService.scala
+++ b/server/src/main/scala/org/broadinstitute/dsp/workbench/welder/server/ObjectService.scala
@@ -73,8 +73,8 @@ class ObjectService(
           case DataUri(data) => Stream.emits(data).through(io.file.writeAll[IO](localAbsolutePath, blockingEc))
           case gsPath: GsPath =>
             for {
-              meta <- googleStorageAlg.gcsToLocalFile(localAbsolutePath, gsPath, traceId)
-              _ <- Stream.eval(updateCache(entry.localObjectPath, meta))
+              meta <- googleStorageAlg.gcsToLocalFile(localAbsolutePath, gsPath, traceId).last
+              _ <- meta.fold[Stream[IO, Unit]](Stream.raiseError[IO](NotFoundException(s"${gsPath} not found")))(m => Stream.eval(updateCache(entry.localObjectPath, m)))
             } yield ()
         }
 

--- a/server/src/main/scala/org/broadinstitute/dsp/workbench/welder/server/ObjectService.scala
+++ b/server/src/main/scala/org/broadinstitute/dsp/workbench/welder/server/ObjectService.scala
@@ -213,7 +213,12 @@ class ObjectService(
           lockToPush <- previousMeta match {
             case Some(meta) =>
               checkLock(meta.lock, now, gsPath.bucketName)
-            case None => IO.raiseError(InvalidLock("Lock not found in local cache. You should acquireLock more often"))
+            case None =>
+              // If this is a new file, acquire lock for current user; If the file actually exists in GCE, delocalize will fail with generation mismatch.
+              for {
+                hashedLockedByCurrentUser <- IO.fromEither(hashString(lockedByString(gsPath.bucketName, config.ownerEmail)))
+                current <- timer.clock.realTime(TimeUnit.MILLISECONDS)
+              } yield lockMetadata(current + config.lockExpiration.toMillis, hashedLockedByCurrentUser)
           }
           generation = previousMeta.flatMap(_.localFileStateInGCS.map(_.generation)).getOrElse(0L)
           delocalizeResp <- googleStorageAlg.delocalize(req.localObjectPath, gsPath, generation, lockToPush, traceId)


### PR DESCRIPTION
* IA-1155 return 404 when localizing a non existent file #33
* Fix a bug where we can't delocalize a new file because we require a lock, but lock can't be obtained when a file doesn't exist in gcs

