### PR TITLE
IA-1098 

### DIFF
--- a/core/README.md
+++ b/core/README.md
@@ -1,0 +1,47 @@
+#Testing `GoogleStorageInterp` Locally
+
+This is an example on how to test Google2 methods locally. In this example, we are testing the 
+GoogleStorageInterpreter.getObjectMetadata method. Before this, we have downloaded a credential JSON 
+file with which we can create a GoogleStorageService object.
+
+Run `sbt server/console`
+
+```scala
+// copy+paste to import all these 
+import org.broadinstitute.dsde.workbench.google2.GoogleStorageService
+import scala.concurrent.ExecutionContext.global
+import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
+import cats.effect.IO
+import org.broadinstitute.dsde.workbench.model.google.GcsBucketName
+import org.broadinstitute.dsde.workbench.google2.GcsBlobName
+import io.chrisdavenport.linebacker.Linebacker
+implicit val cs = IO.contextShift(global)
+implicit val t = IO.timer(global)
+implicit def unsafeLogger = Slf4jLogger.getLogger[IO]  
+implicit val lineBacker = Linebacker.fromExecutionContext[IO](global)
+import org.broadinstitute.dsp.workbench.welder.GoogleStorageAlg
+import org.broadinstitute.dsp.workbench.welder.GoogleStorageAlgConfig
+import java.nio.file.Paths
+import org.broadinstitute.dsp.workbench.welder.LocalDirectory.LocalBaseDirectory
+import org.broadinstitute.dsp.workbench.welder.CloudStorageDirectory
+import org.broadinstitute.dsde.workbench.model.TraceId
+import org.broadinstitute.dsp.workbench.welder.RelativePath
+import org.broadinstitute.dsp.workbench.welder.LocalDirectory.LocalBaseDirectory
+import java.util.UUID
+
+val traceId = TraceId(UUID.randomUUID)
+```
+
+`scala> GoogleStorageService.resource[IO]("credentials.json")`
+
+SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
+SLF4J: Defaulting to no-operation (NOP) logger implementation
+SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
+res0: cats.effect.Resource[cats.effect.IO,org.broadinstitute.dsde.workbench.google2.GoogleStorageService[cats.effect.IO]] = Bind(Bind(Allocate(<function1>),org.broadinstitute.dsde.workbench.google2.GoogleStorageInterpreter$$$Lambda$5201/1070179104@19a35b53),cats.effect.Resource$$Lambda$5203/746114085@43398b6)
+
+`scala> val googleStorageAlg = res0.map(s => GoogleStorageAlg.fromGoogle(GoogleStorageAlgConfig(Paths.get("/tmp")), s))`
+
+res2: cats.effect.IO[Map[String,String]] = IO$1818107578
+
+`scala> val res = googleStorageAlg.use(s => s.localizeCloudDirectory(LocalBaseDirectory(RelativePath(Paths.get("edit"))), CloudStorageDirectory(GcsBucketName("qi-test"),None), Paths.get("/tmp"), traceId).compile.drain)`
+`scala> res.unsafeRunSync()`

--- a/core/src/main/scala/org/broadinstitute/dsp/workbench/welder/BackgroundTask.scala
+++ b/core/src/main/scala/org/broadinstitute/dsp/workbench/welder/BackgroundTask.scala
@@ -59,7 +59,7 @@ class BackgroundTask(
       _ <- storageLinks.values.toList.traverse { storageLink =>
         logger.info(s"syncing file from ${storageLink.cloudStorageDirectory}") >>
         (googleStorageAlg
-          .localizeCloudDirectory(storageLink.localBaseDirectory.path, storageLink.cloudStorageDirectory, config.workingDirectory, traceId)
+          .localizeCloudDirectory(storageLink.localBaseDirectory.path, storageLink.cloudStorageDirectory, config.workingDirectory, storageLink.pattern, traceId)
           .through(metadataCacheAlg.updateCachePipe))
           .compile
           .drain

--- a/core/src/main/scala/org/broadinstitute/dsp/workbench/welder/GoogleStorageAlg.scala
+++ b/core/src/main/scala/org/broadinstitute/dsp/workbench/welder/GoogleStorageAlg.scala
@@ -10,6 +10,8 @@ import org.broadinstitute.dsde.workbench.google2.{Crc32, GoogleStorageService, R
 import org.broadinstitute.dsde.workbench.model.TraceId
 import org.broadinstitute.dsp.workbench.welder.SourceUri.GsPath
 
+import scala.util.matching.Regex
+
 trait GoogleStorageAlg {
   def updateMetadata(gsPath: GsPath, traceId: TraceId, metadata: Map[String, String]): IO[UpdateMetadataResponse]
   def retrieveAdaptedGcsMetadata(localPath: RelativePath, gsPath: GsPath, traceId: TraceId): IO[Option[AdaptedGcsMetadata]]
@@ -34,12 +36,7 @@ trait GoogleStorageAlg {
     * @param cloudStorageDirectory: GCS directory where files will be download from
     * @return AdaptedGcsMetadataCache that should be added to local metadata cache
     */
-  def localizeCloudDirectory(
-      localBaseDirectory: RelativePath,
-      cloudStorageDirectory: CloudStorageDirectory,
-      workingDir: Path,
-      traceId: TraceId
-  ): Stream[IO, AdaptedGcsMetadataCache]
+  def localizeCloudDirectory(localBaseDirectory: RelativePath, cloudStorageDirectory: CloudStorageDirectory, workingDir: Path, pattern: Regex, traceId: TraceId): Stream[IO, AdaptedGcsMetadataCache]
 }
 
 object GoogleStorageAlg {

--- a/core/src/main/scala/org/broadinstitute/dsp/workbench/welder/GoogleStorageAlg.scala
+++ b/core/src/main/scala/org/broadinstitute/dsp/workbench/welder/GoogleStorageAlg.scala
@@ -8,6 +8,7 @@ import io.chrisdavenport.linebacker.Linebacker
 import io.chrisdavenport.log4cats.Logger
 import org.broadinstitute.dsde.workbench.google2.{Crc32, GoogleStorageService, RemoveObjectResult}
 import org.broadinstitute.dsde.workbench.model.TraceId
+import org.broadinstitute.dsp.workbench.welder.LocalDirectory.LocalBaseDirectory
 import org.broadinstitute.dsp.workbench.welder.SourceUri.GsPath
 
 trait GoogleStorageAlg {
@@ -26,6 +27,15 @@ trait GoogleStorageAlg {
       userDefinedMeta: Map[String, String],
       traceId: TraceId
   ): IO[DelocalizeResponse]
+
+  /**
+    * Recursively download files in cloudStorageDirectory to local directory.
+    * If file exists locally, we don't download the file
+    * @param localBaseDirectory: base directory where remote files will be download to
+    * @param cloudStorageDirectory: GCS directory where files will be download from
+    * @return AdaptedGcsMetadataCache that should be added to local metadata cache
+    */
+  def localizeCloudDirectory(localBaseDirectory: LocalBaseDirectory, cloudStorageDirectory: CloudStorageDirectory, workingDir: Path, traceId: TraceId): Stream[IO, AdaptedGcsMetadataCache]
 }
 
 object GoogleStorageAlg {

--- a/core/src/main/scala/org/broadinstitute/dsp/workbench/welder/GoogleStorageAlg.scala
+++ b/core/src/main/scala/org/broadinstitute/dsp/workbench/welder/GoogleStorageAlg.scala
@@ -8,7 +8,6 @@ import io.chrisdavenport.linebacker.Linebacker
 import io.chrisdavenport.log4cats.Logger
 import org.broadinstitute.dsde.workbench.google2.{Crc32, GoogleStorageService, RemoveObjectResult}
 import org.broadinstitute.dsde.workbench.model.TraceId
-import org.broadinstitute.dsp.workbench.welder.LocalDirectory.LocalBaseDirectory
 import org.broadinstitute.dsp.workbench.welder.SourceUri.GsPath
 
 trait GoogleStorageAlg {
@@ -36,7 +35,7 @@ trait GoogleStorageAlg {
     * @return AdaptedGcsMetadataCache that should be added to local metadata cache
     */
   def localizeCloudDirectory(
-      localBaseDirectory: LocalBaseDirectory,
+      localBaseDirectory: RelativePath,
       cloudStorageDirectory: CloudStorageDirectory,
       workingDir: Path,
       traceId: TraceId

--- a/core/src/main/scala/org/broadinstitute/dsp/workbench/welder/GoogleStorageAlg.scala
+++ b/core/src/main/scala/org/broadinstitute/dsp/workbench/welder/GoogleStorageAlg.scala
@@ -35,7 +35,12 @@ trait GoogleStorageAlg {
     * @param cloudStorageDirectory: GCS directory where files will be download from
     * @return AdaptedGcsMetadataCache that should be added to local metadata cache
     */
-  def localizeCloudDirectory(localBaseDirectory: LocalBaseDirectory, cloudStorageDirectory: CloudStorageDirectory, workingDir: Path, traceId: TraceId): Stream[IO, AdaptedGcsMetadataCache]
+  def localizeCloudDirectory(
+      localBaseDirectory: LocalBaseDirectory,
+      cloudStorageDirectory: CloudStorageDirectory,
+      workingDir: Path,
+      traceId: TraceId
+  ): Stream[IO, AdaptedGcsMetadataCache]
 }
 
 object GoogleStorageAlg {

--- a/core/src/main/scala/org/broadinstitute/dsp/workbench/welder/GoogleStorageInterp.scala
+++ b/core/src/main/scala/org/broadinstitute/dsp/workbench/welder/GoogleStorageInterp.scala
@@ -84,7 +84,7 @@ class GoogleStorageInterp(config: GoogleStorageAlgConfig, googleStorageService: 
   }
 
   override def localizeCloudDirectory(
-      localBaseDirectory: LocalDirectory.LocalBaseDirectory,
+      localBaseDirectory: RelativePath,
       cloudStorageDirectory: CloudStorageDirectory,
       workingDir: Path,
       traceId: TraceId

--- a/core/src/main/scala/org/broadinstitute/dsp/workbench/welder/GoogleStorageInterp.scala
+++ b/core/src/main/scala/org/broadinstitute/dsp/workbench/welder/GoogleStorageInterp.scala
@@ -83,12 +83,24 @@ class GoogleStorageInterp(config: GoogleStorageAlgConfig, googleStorageService: 
     }
   }
 
-  override def localizeCloudDirectory(localBaseDirectory: LocalDirectory.LocalBaseDirectory, cloudStorageDirectory: CloudStorageDirectory, workingDir: Path, traceId: TraceId): Stream[IO, AdaptedGcsMetadataCache] = {
+  override def localizeCloudDirectory(
+      localBaseDirectory: LocalDirectory.LocalBaseDirectory,
+      cloudStorageDirectory: CloudStorageDirectory,
+      workingDir: Path,
+      traceId: TraceId
+  ): Stream[IO, AdaptedGcsMetadataCache] = {
     val res = for {
-      blob <- googleStorageService.listBlobsWithPrefix(cloudStorageDirectory.bucketName, cloudStorageDirectory.blobPath.map(_.asString).getOrElse(""), true, 1000, Some(traceId))
+      blob <- googleStorageService.listBlobsWithPrefix(
+        cloudStorageDirectory.bucketName,
+        cloudStorageDirectory.blobPath.map(_.asString).getOrElse(""),
+        true,
+        1000,
+        Some(traceId)
+      )
       localPath <- Stream.eval(IO.fromEither(getLocalPath(localBaseDirectory, cloudStorageDirectory.blobPath, blob.getName)))
       localAbsolutePath <- Stream.fromEither[IO](Either.catchNonFatal(workingDir.resolve(localPath.asPath)))
-      result <- if(localAbsolutePath.toFile.exists()) Stream(None).covary[IO] else {
+      result <- if (localAbsolutePath.toFile.exists()) Stream(None).covary[IO]
+      else {
         val res = for {
           metadata <- adaptMetadata(Crc32(blob.getCrc32c), Option(blob.getMetadata).map(_.asScala.toMap).getOrElse(Map.empty), blob.getGeneration)
           metadataCache = AdaptedGcsMetadataCache(localPath, RemoteState(metadata.lock, metadata.crc32c), Some(metadata.generation))

--- a/core/src/main/scala/org/broadinstitute/dsp/workbench/welder/MetadataCacheAlg.scala
+++ b/core/src/main/scala/org/broadinstitute/dsp/workbench/welder/MetadataCacheAlg.scala
@@ -1,0 +1,22 @@
+package org.broadinstitute.dsp.workbench.welder
+
+import java.nio.file.Path
+
+import cats.effect.IO
+import fs2.Pipe
+
+trait MetadataCacheAlg {
+  def updateRemoteStateCache(localPath: RelativePath, remoteState: RemoteState): IO[Unit]
+
+  def updateLocalFileStateCache(localPath: RelativePath, remoteState: RemoteState, localFileGeneration: Long): IO[Unit]
+
+  def updateCache(localPath: RelativePath, adaptedGcsMetadata: AdaptedGcsMetadata): IO[Unit]
+
+  def getCache(localPath: RelativePath): IO[Option[AdaptedGcsMetadataCache]]
+
+  def removeCache(localPath: RelativePath): IO[Unit]
+
+  def updateCachePipe: Pipe[IO, AdaptedGcsMetadataCache, Unit]
+}
+
+final case class CacheAlgConfig(storageLinksPath: Path, metadataCachePath: Path)

--- a/core/src/main/scala/org/broadinstitute/dsp/workbench/welder/MetadataCacheInterp.scala
+++ b/core/src/main/scala/org/broadinstitute/dsp/workbench/welder/MetadataCacheInterp.scala
@@ -1,0 +1,45 @@
+package org.broadinstitute.dsp.workbench.welder
+
+import cats.effect.IO
+import fs2.{Pipe, Stream}
+
+class MetadataCacheInterp(metadataCache: MetadataCache) extends MetadataCacheAlg {
+  def updateRemoteStateCache(localPath: RelativePath, remoteState: RemoteState): IO[Unit] =
+    metadataCache.modify { mp =>
+      val previousMeta = mp.get(localPath)
+      val newCache = mp + (localPath -> AdaptedGcsMetadataCache(localPath, remoteState, previousMeta.flatMap(_.localFileGeneration)))
+      (newCache, ())
+    }
+
+  def updateLocalFileStateCache(localPath: RelativePath, remoteState: RemoteState, localFileGeneration: Long): IO[Unit] =
+    metadataCache.modify { mp =>
+      val previousMeta = mp.get(localPath)
+      val newCache = mp + (localPath -> AdaptedGcsMetadataCache(localPath, remoteState, Some(localFileGeneration)))
+      (newCache, ())
+    }
+
+  def updateCache(localPath: RelativePath, adaptedGcsMetadata: AdaptedGcsMetadata): IO[Unit] =
+    metadataCache.modify { mp =>
+      val newCache = mp + (localPath -> AdaptedGcsMetadataCache(
+        localPath,
+        RemoteState(adaptedGcsMetadata.lock, adaptedGcsMetadata.crc32c),
+        Some(adaptedGcsMetadata.generation)
+      ))
+      (newCache, ())
+    }
+
+  val updateCachePipe: Pipe[IO, AdaptedGcsMetadataCache, Unit] = in => {
+    in.flatMap {
+      metadata =>
+        val res = metadataCache.modify { mp =>
+          val newCache = mp + (metadata.localPath -> metadata)
+          (newCache, ())
+        }
+        Stream.eval(res)
+    }
+  }
+
+  override def getCache(localPath: RelativePath): IO[Option[AdaptedGcsMetadataCache]] = metadataCache.get.map(_.get(localPath))
+
+  override def removeCache(localPath: RelativePath): IO[Unit] = metadataCache.modify(mp => (mp - localPath, ()))
+}

--- a/core/src/main/scala/org/broadinstitute/dsp/workbench/welder/MetadataCacheInterp.scala
+++ b/core/src/main/scala/org/broadinstitute/dsp/workbench/welder/MetadataCacheInterp.scala
@@ -29,13 +29,12 @@ class MetadataCacheInterp(metadataCache: MetadataCache) extends MetadataCacheAlg
     }
 
   val updateCachePipe: Pipe[IO, AdaptedGcsMetadataCache, Unit] = in => {
-    in.flatMap {
-      metadata =>
-        val res = metadataCache.modify { mp =>
-          val newCache = mp + (metadata.localPath -> metadata)
-          (newCache, ())
-        }
-        Stream.eval(res)
+    in.flatMap { metadata =>
+      val res = metadataCache.modify { mp =>
+        val newCache = mp + (metadata.localPath -> metadata)
+        (newCache, ())
+      }
+      Stream.eval(res)
     }
   }
 

--- a/core/src/main/scala/org/broadinstitute/dsp/workbench/welder/model.scala
+++ b/core/src/main/scala/org/broadinstitute/dsp/workbench/welder/model.scala
@@ -7,6 +7,8 @@ import ca.mrvisser.sealerate
 import org.broadinstitute.dsde.workbench.google2.{Crc32, GcsBlobName}
 import org.broadinstitute.dsde.workbench.model.google.GcsBucketName
 
+import scala.util.matching.Regex
+
 sealed abstract class SyncStatus extends Product with Serializable
 object SyncStatus {
   // crc32c match
@@ -61,12 +63,7 @@ object LocalDirectory {
 
 final case class CloudStorageDirectory(bucketName: GcsBucketName, blobPath: Option[BlobPath])
 
-final case class StorageLink(
-    localBaseDirectory: LocalDirectory,
-    localSafeModeBaseDirectory: LocalDirectory,
-    cloudStorageDirectory: CloudStorageDirectory,
-    pattern: String
-)
+final case class StorageLink(localBaseDirectory: LocalDirectory, localSafeModeBaseDirectory: LocalDirectory, cloudStorageDirectory: CloudStorageDirectory, pattern: Regex)
 
 final case class HashedLockedBy(asString: String) extends AnyVal
 

--- a/core/src/main/scala/org/broadinstitute/dsp/workbench/welder/package.scala
+++ b/core/src/main/scala/org/broadinstitute/dsp/workbench/welder/package.scala
@@ -18,7 +18,6 @@ import io.circe.{Decoder, Encoder, Printer}
 import org.broadinstitute.dsde.workbench.google2.GcsBlobName
 import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
 import org.broadinstitute.dsde.workbench.model.google.GcsBucketName
-import org.broadinstitute.dsp.workbench.welder.LocalDirectory.LocalBaseDirectory
 import org.broadinstitute.dsp.workbench.welder.SourceUri.GsPath
 import org.typelevel.jawn.AsyncParser
 
@@ -83,13 +82,13 @@ package object welder {
     * @param blobName actual blob name
     * @return
     */
-  def getLocalPath(localBaseDirectory: LocalBaseDirectory, blobPath: Option[BlobPath], blobName: String): Either[Throwable, RelativePath] =
+  def getLocalPath(localBaseDirectory: RelativePath, blobPath: Option[BlobPath], blobName: String): Either[Throwable, RelativePath] =
     for {
       localName <- blobPath match {
         case Some(bp) => Either.catchNonFatal(Paths.get(bp.asString).relativize(Paths.get(blobName)))
         case None => Right(Paths.get(blobName))
       }
-      localPath <- Either.catchNonFatal(localBaseDirectory.path.asPath.resolve(localName))
+      localPath <- Either.catchNonFatal(localBaseDirectory.asPath.resolve(localName))
     } yield RelativePath(localPath)
 
   val base64Decoder = Base64.getDecoder()

--- a/core/src/main/scala/org/broadinstitute/dsp/workbench/welder/package.scala
+++ b/core/src/main/scala/org/broadinstitute/dsp/workbench/welder/package.scala
@@ -2,7 +2,7 @@ package org.broadinstitute.dsp.workbench
 
 import java.io.File
 import java.math.BigInteger
-import java.nio.file.{Path, StandardOpenOption}
+import java.nio.file.{Path, Paths, StandardOpenOption}
 import java.security.MessageDigest
 import java.util.Base64
 
@@ -12,18 +12,19 @@ import cats.effect.{Concurrent, ContextShift, IO, Resource, Sync}
 import cats.implicits._
 import fs2.{Pipe, Stream}
 import io.chrisdavenport.log4cats.Logger
-import io.circe.{Decoder, Encoder, Printer}
 import io.circe.fs2._
+import io.circe.syntax._
+import io.circe.{Decoder, Encoder, Printer}
 import org.broadinstitute.dsde.workbench.google2.GcsBlobName
 import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
 import org.broadinstitute.dsde.workbench.model.google.GcsBucketName
+import org.broadinstitute.dsp.workbench.welder.LocalDirectory.LocalBaseDirectory
 import org.broadinstitute.dsp.workbench.welder.SourceUri.GsPath
 import org.typelevel.jawn.AsyncParser
-import io.circe.syntax._
 
-import scala.language.implicitConversions
 import scala.concurrent.ExecutionContext
 import scala.concurrent.ExecutionContext.global
+import scala.language.implicitConversions
 
 package object welder {
   val LAST_LOCKED_BY = "lastLockedBy"
@@ -76,6 +77,22 @@ package object welder {
     }
   }
 
+  /**
+    * @param localBaseDirectory local base directory
+    * @param blobPath blob path defined in CloudStorageDirectory
+    * @param blobName actual blob name
+    * @return
+    */
+  def getLocalPath(localBaseDirectory: LocalBaseDirectory, blobPath: Option[BlobPath], blobName: String): Either[Throwable, RelativePath] = {
+    for {
+      localName <- blobPath match {
+        case Some(bp) => Either.catchNonFatal (Paths.get(bp.asString).relativize(Paths.get(blobName)))
+        case None => Right(Paths.get(blobName))
+      }
+      localPath <- Either.catchNonFatal(localBaseDirectory.path.asPath.resolve(localName))
+    } yield RelativePath(localPath)
+  }
+
   val base64Decoder = Base64.getDecoder()
   def base64DecoderPipe[F[_]: Sync]: Pipe[F, String, Byte] = in => {
     in.evalMap(s => Sync[F].catchNonFatal(base64Decoder.decode(s)))
@@ -124,13 +141,12 @@ package object welder {
       )
     } yield ref
 
-  private[welder] def flushCache[A, B: Decoder: Encoder](path: Path, blockingEc: ExecutionContext, ref: Ref[IO, Map[A, B]])(
-      implicit cs: ContextShift[IO]
-  ): Stream[IO, Unit] =
-    Stream
-      .eval(ref.get)
-      .flatMap(x => Stream.emits(x.values.toSet.asJson.pretty(Printer.noSpaces).getBytes("UTF-8")))
-      .through(fs2.io.file.writeAll[IO](path, blockingEc, writeFileOptions))
+  def flushCache[A, B: Decoder : Encoder](path: Path, blockingEc: ExecutionContext, ref: Ref[IO, Map[A, B]])(
+    implicit cs: ContextShift[IO]
+  ): Stream[IO, Unit] =  Stream
+    .eval(ref.get)
+    .flatMap(x => Stream.emits(x.values.toSet.asJson.pretty(Printer.noSpaces).getBytes("UTF-8")))
+    .through(fs2.io.file.writeAll[IO](path, blockingEc, writeFileOptions))
 
   private[welder] val writeFileOptions = List(StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING)
 

--- a/core/src/main/scala/org/broadinstitute/dsp/workbench/welder/package.scala
+++ b/core/src/main/scala/org/broadinstitute/dsp/workbench/welder/package.scala
@@ -83,15 +83,14 @@ package object welder {
     * @param blobName actual blob name
     * @return
     */
-  def getLocalPath(localBaseDirectory: LocalBaseDirectory, blobPath: Option[BlobPath], blobName: String): Either[Throwable, RelativePath] = {
+  def getLocalPath(localBaseDirectory: LocalBaseDirectory, blobPath: Option[BlobPath], blobName: String): Either[Throwable, RelativePath] =
     for {
       localName <- blobPath match {
-        case Some(bp) => Either.catchNonFatal (Paths.get(bp.asString).relativize(Paths.get(blobName)))
+        case Some(bp) => Either.catchNonFatal(Paths.get(bp.asString).relativize(Paths.get(blobName)))
         case None => Right(Paths.get(blobName))
       }
       localPath <- Either.catchNonFatal(localBaseDirectory.path.asPath.resolve(localName))
     } yield RelativePath(localPath)
-  }
 
   val base64Decoder = Base64.getDecoder()
   def base64DecoderPipe[F[_]: Sync]: Pipe[F, String, Byte] = in => {
@@ -141,12 +140,13 @@ package object welder {
       )
     } yield ref
 
-  def flushCache[A, B: Decoder : Encoder](path: Path, blockingEc: ExecutionContext, ref: Ref[IO, Map[A, B]])(
-    implicit cs: ContextShift[IO]
-  ): Stream[IO, Unit] =  Stream
-    .eval(ref.get)
-    .flatMap(x => Stream.emits(x.values.toSet.asJson.pretty(Printer.noSpaces).getBytes("UTF-8")))
-    .through(fs2.io.file.writeAll[IO](path, blockingEc, writeFileOptions))
+  def flushCache[A, B: Decoder: Encoder](path: Path, blockingEc: ExecutionContext, ref: Ref[IO, Map[A, B]])(
+      implicit cs: ContextShift[IO]
+  ): Stream[IO, Unit] =
+    Stream
+      .eval(ref.get)
+      .flatMap(x => Stream.emits(x.values.toSet.asJson.pretty(Printer.noSpaces).getBytes("UTF-8")))
+      .through(fs2.io.file.writeAll[IO](path, blockingEc, writeFileOptions))
 
   private[welder] val writeFileOptions = List(StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING)
 

--- a/core/src/test/scala/org/broadinstitute/dsp/workbench/welder/Generators.scala
+++ b/core/src/test/scala/org/broadinstitute/dsp/workbench/welder/Generators.scala
@@ -48,7 +48,7 @@ object Generators {
     localBaseDirectory <- genLocalBaseDirectory
     localSafeDirectory <- genLocalSafeBaseDirectory
     cloudStorageDirectory <- genCloudStorageDirectory
-  } yield StorageLink(localBaseDirectory, localSafeDirectory, cloudStorageDirectory, "*.ipynb")
+  } yield StorageLink(localBaseDirectory, localSafeDirectory, cloudStorageDirectory, "\\.ipynb$".r)
 
   val genWorkbenchEmail = Gen.uuid.map(x => WorkbenchEmail(s"$x@gmail.com"))
 

--- a/core/src/test/scala/org/broadinstitute/dsp/workbench/welder/GoogleStorageInterpSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsp/workbench/welder/GoogleStorageInterpSpec.scala
@@ -2,19 +2,25 @@ package org.broadinstitute.dsp.workbench.welder
 
 import java.io.File
 import java.nio.file.Paths
+import java.util.UUID
 import java.util.UUID.randomUUID
 
-import cats.implicits._
 import cats.effect.IO
+import cats.effect.concurrent.Ref
+import cats.implicits._
 import com.google.api.client.googleapis.json.GoogleJsonError
 import com.google.cloud.storage.Blob
 import fs2.Stream
+import org.broadinstitute.dsde.workbench.google2.Generators.{genGcsBlobName, genGcsObjectBody}
+import org.broadinstitute.dsde.workbench.google2.GoogleStorageInterpreterSpec.objectType
 import org.broadinstitute.dsde.workbench.google2.mock.{BaseFakeGoogleStorage, FakeGoogleStorageInterpreter}
 import org.broadinstitute.dsde.workbench.google2.{GcsBlobName, GetMetadataResponse}
 import org.broadinstitute.dsde.workbench.model.TraceId
 import org.broadinstitute.dsde.workbench.model.google.GcsBucketName
 import org.broadinstitute.dsp.workbench.welder.Generators._
+import org.broadinstitute.dsp.workbench.welder.LocalDirectory.LocalBaseDirectory
 import org.broadinstitute.dsp.workbench.welder.SourceUri.GsPath
+import org.scalacheck.Gen
 import org.scalatest.FlatSpec
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 
@@ -115,6 +121,45 @@ class GoogleStorageInterpSpec extends FlatSpec with ScalaCheckPropertyChecks wit
         res.compile.drain.unsafeRunSync()
     }
   }
+
+  //TODO: turn this on if emulator has better support for list objects with prefix
+//  "localizeCloudDirectory" should "recursively download files for a given CloudStorageDirectory" in {
+//    forAll {
+//      (cloudStorageDirectoryNew: CloudStorageDirectory) =>
+//        val cloudStorageDirectory = if(cloudStorageDirectoryNew.blobPath.isDefined) cloudStorageDirectoryNew else cloudStorageDirectoryNew.copy(blobPath = Some(BlobPath("prefix")))
+//        val allObjects = Gen.listOfN(4, genGcsBlobName).sample.get.map {
+//          x =>
+//            cloudStorageDirectory.blobPath match {
+//              case Some(bp) => GcsBlobName(s"${bp.asString}/${x.value}")
+//              case None => GcsBlobName(s"${x.value}")
+//            }
+//        }
+//        val objectBody = genGcsObjectBody.sample.get
+//        val emptyStorageLinksCache = Ref.unsafe[IO, Map[RelativePath, StorageLink]](Map.empty)
+//        val googleStorage = GoogleStorageAlg.fromGoogle(GoogleStorageAlgConfig(Paths.get("/tmp")), FakeGoogleStorageInterpreter)
+//        val workingDir = Paths.get("/tmp")
+//        val localBaseDir = LocalBaseDirectory(RelativePath(Paths.get("edit")))
+//
+//        val res = for {
+//          _ <- allObjects.parTraverse(obj => FakeGoogleStorageInterpreter.createBlob(cloudStorageDirectory.bucketName, obj, objectBody, objectType).compile.drain)
+//          _ <- googleStorage.localizeCloudDirectory(localBaseDir, cloudStorageDirectory, workingDir, TraceId(UUID.randomUUID())).compile.drain
+//          objectsList <- FakeGoogleStorageInterpreter.listBlobsWithPrefix(cloudStorageDirectory.bucketName, cloudStorageDirectory.blobPath.map(_.asString).getOrElse(""), true).compile.toList
+//        } yield {
+//          val prefix = (workingDir.resolve(localBaseDir.path.asPath))
+//          val allFiles = allObjects.map {blobName =>
+//            cloudStorageDirectory.blobPath match {
+//              case Some(bp) =>
+//                prefix.resolve(Paths.get(bp.asString).relativize(Paths.get(blobName.value)))
+//              case None =>
+//                prefix.resolve(Paths.get(blobName.value))
+//            }
+//          }
+//          allFiles.forall(_.toFile.exists()) shouldBe true
+//          allFiles.foreach(_.toFile.delete())
+//        }
+//        res.unsafeRunSync()
+//    }
+//  }
 }
 
 

--- a/core/src/test/scala/org/broadinstitute/dsp/workbench/welder/GoogleStorageInterpSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsp/workbench/welder/GoogleStorageInterpSpec.scala
@@ -18,7 +18,6 @@ import org.broadinstitute.dsde.workbench.google2.{GcsBlobName, GetMetadataRespon
 import org.broadinstitute.dsde.workbench.model.TraceId
 import org.broadinstitute.dsde.workbench.model.google.GcsBucketName
 import org.broadinstitute.dsp.workbench.welder.Generators._
-import org.broadinstitute.dsp.workbench.welder.LocalDirectory.LocalBaseDirectory
 import org.broadinstitute.dsp.workbench.welder.SourceUri.GsPath
 import org.scalacheck.Gen
 import org.scalatest.FlatSpec
@@ -136,13 +135,13 @@ class GoogleStorageInterpSpec extends FlatSpec with ScalaCheckPropertyChecks wit
         val emptyStorageLinksCache = Ref.unsafe[IO, Map[RelativePath, StorageLink]](Map.empty)
         val googleStorage = GoogleStorageAlg.fromGoogle(GoogleStorageAlgConfig(Paths.get("/tmp")), FakeGoogleStorageInterpreter)
         val workingDir = Paths.get("/tmp")
-        val localBaseDir = LocalBaseDirectory(RelativePath(Paths.get("edit")))
+        val localBaseDir = RelativePath(Paths.get("edit"))
 
         val res = for {
           _ <- allObjects.traverse(obj => FakeGoogleStorageInterpreter.createBlob(cloudStorageDirectory.bucketName, obj, objectBody, objectType).compile.drain)
           _ <- googleStorage.localizeCloudDirectory(localBaseDir, cloudStorageDirectory, workingDir, TraceId(UUID.randomUUID())).compile.drain
         } yield {
-          val prefix = (workingDir.resolve(localBaseDir.path.asPath))
+          val prefix = (workingDir.resolve(localBaseDir.asPath))
           val allFiles = allObjects.map {blobName =>
             cloudStorageDirectory.blobPath match {
               case Some(bp) =>

--- a/core/src/test/scala/org/broadinstitute/dsp/workbench/welder/JsonCodecSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsp/workbench/welder/JsonCodecSpec.scala
@@ -6,7 +6,7 @@ import org.broadinstitute.dsp.workbench.welder.Generators.arbGcsBucketName
 import org.broadinstitute.dsp.workbench.welder.JsonCodec._
 import org.scalatest.FlatSpec
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
-import io.circe.parser.parse
+
 import scala.util.matching.Regex
 
 class JsonCodecSpec extends FlatSpec with ScalaCheckPropertyChecks with WelderTestSuite {
@@ -32,10 +32,9 @@ class JsonCodecSpec extends FlatSpec with ScalaCheckPropertyChecks with WelderTe
 
   "regexDecoder" should "be able to decode expected regex" in {
     val res = for {
-      json <- parse("""\.ipynb$""")
-      regex <- json.as[Regex]
+      regex <- Json.fromString("\\.ipynb$").as[Regex]
     } yield regex
-
-    res shouldBe(Right("\\.ipynb$".r))
+    val regex = res.getOrElse(throw new Exception("fail to turn strng into regex"))
+    assert(regexEq.eqv(regex, "\\.ipynb$".r))
   }
 }

--- a/core/src/test/scala/org/broadinstitute/dsp/workbench/welder/JsonCodecSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsp/workbench/welder/JsonCodecSpec.scala
@@ -6,6 +6,8 @@ import org.broadinstitute.dsp.workbench.welder.Generators.arbGcsBucketName
 import org.broadinstitute.dsp.workbench.welder.JsonCodec._
 import org.scalatest.FlatSpec
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+import io.circe.parser.parse
+import scala.util.matching.Regex
 
 class JsonCodecSpec extends FlatSpec with ScalaCheckPropertyChecks with WelderTestSuite {
   "cloudStorageDirectoryDecoder" should "be able to parse cloudStorageDirectory correctly" in {
@@ -26,5 +28,14 @@ class JsonCodecSpec extends FlatSpec with ScalaCheckPropertyChecks with WelderTe
         val res = Json.fromString(inputString).as[CloudStorageDirectory]
         res shouldBe(Right(CloudStorageDirectory(bucketName, None)))
     }
+  }
+
+  "regexDecoder" should "be able to decode expected regex" in {
+    val res = for {
+      json <- parse("""\.ipynb$""")
+      regex <- json.as[Regex]
+    } yield regex
+
+    res shouldBe(Right("\\.ipynb$".r))
   }
 }

--- a/core/src/test/scala/org/broadinstitute/dsp/workbench/welder/PackageSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsp/workbench/welder/PackageSpec.scala
@@ -6,6 +6,7 @@ import org.broadinstitute.dsde.workbench.google2.GcsBlobName
 import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
 import org.broadinstitute.dsde.workbench.model.google.GcsBucketName
 import org.broadinstitute.dsp.workbench.welder.Generators.arbGcsBucketName
+import org.broadinstitute.dsp.workbench.welder.LocalDirectory.LocalBaseDirectory
 import org.broadinstitute.dsp.workbench.welder.SourceUri.GsPath
 import org.scalatest.FlatSpec
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
@@ -44,6 +45,20 @@ class PackageSpec extends FlatSpec with ScalaCheckPropertyChecks with WelderTest
     val localPath = Paths.get("workspaces/ws1/sub/notebook1.ipynb")
     val basePath = RelativePath(Paths.get("workspaces/ws1"))
     getFullBlobName(basePath, localPath, None) shouldBe(GcsBlobName("sub/notebook1.ipynb"))
+  }
+
+  "getLocalPath" should "calculate local path correctly when blobPath exists" in {
+    val baseDirectory = LocalBaseDirectory(RelativePath(Paths.get("edit")))
+    val blobPath = Some(BlobPath("directory"))
+    val blobName = "directory/a/blob1"
+    getLocalPath(baseDirectory, blobPath, blobName) shouldBe(Right(RelativePath(Paths.get("edit/a/blob1"))))
+  }
+
+  it should "calculate local path correctly when blobPath is None" in {
+    val baseDirectory = LocalBaseDirectory(RelativePath(Paths.get("edit")))
+    val blobPath = None
+    val blobName = "directory/a/blob1"
+    getLocalPath(baseDirectory, blobPath, blobName) shouldBe(Right(RelativePath(Paths.get("edit/directory/a/blob1"))))
   }
 
   "hashMetadata" should "consistently hash a string" in {

--- a/core/src/test/scala/org/broadinstitute/dsp/workbench/welder/PackageSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsp/workbench/welder/PackageSpec.scala
@@ -6,7 +6,6 @@ import org.broadinstitute.dsde.workbench.google2.GcsBlobName
 import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
 import org.broadinstitute.dsde.workbench.model.google.GcsBucketName
 import org.broadinstitute.dsp.workbench.welder.Generators.arbGcsBucketName
-import org.broadinstitute.dsp.workbench.welder.LocalDirectory.LocalBaseDirectory
 import org.broadinstitute.dsp.workbench.welder.SourceUri.GsPath
 import org.scalatest.FlatSpec
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
@@ -48,14 +47,14 @@ class PackageSpec extends FlatSpec with ScalaCheckPropertyChecks with WelderTest
   }
 
   "getLocalPath" should "calculate local path correctly when blobPath exists" in {
-    val baseDirectory = LocalBaseDirectory(RelativePath(Paths.get("edit")))
+    val baseDirectory = RelativePath(Paths.get("edit"))
     val blobPath = Some(BlobPath("directory"))
     val blobName = "directory/a/blob1"
     getLocalPath(baseDirectory, blobPath, blobName) shouldBe(Right(RelativePath(Paths.get("edit/a/blob1"))))
   }
 
   it should "calculate local path correctly when blobPath is None" in {
-    val baseDirectory = LocalBaseDirectory(RelativePath(Paths.get("edit")))
+    val baseDirectory = RelativePath(Paths.get("edit"))
     val blobPath = None
     val blobName = "directory/a/blob1"
     getLocalPath(baseDirectory, blobPath, blobName) shouldBe(Right(RelativePath(Paths.get("edit/directory/a/blob1"))))

--- a/core/src/test/scala/org/broadinstitute/dsp/workbench/welder/WelderTestSuite.scala
+++ b/core/src/test/scala/org/broadinstitute/dsp/workbench/welder/WelderTestSuite.scala
@@ -11,6 +11,7 @@ import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.ExecutionContext.global
+import scala.util.matching.Regex
 
 trait WelderTestSuite extends Matchers with ScalaCheckPropertyChecks with Configuration {
   implicit val executionContext: ExecutionContext = scala.concurrent.ExecutionContext.global
@@ -22,6 +23,8 @@ trait WelderTestSuite extends Matchers with ScalaCheckPropertyChecks with Config
   implicit override val generatorDrivenConfig: PropertyCheckConfiguration = PropertyCheckConfiguration(minSuccessful = 3)
 
   // Regex's equals doesn't compare Regex as expected. Hence, we define Eq[StorageLink] when we need to check equality of two StorageLink
+  implicit val regexEq: Eq[Regex] = Eq.instance((r1, r2) => r1.pattern.pattern == r2.pattern.pattern)
+
   implicit val storageLinkEq: Eq[StorageLink] = Eq.instance{ (s1, s2) =>
     s1.pattern.pattern.pattern == s2.pattern.pattern.pattern &&
     s1.localBaseDirectory == s2.localBaseDirectory &&

--- a/core/src/test/scala/org/broadinstitute/dsp/workbench/welder/WelderTestSuite.scala
+++ b/core/src/test/scala/org/broadinstitute/dsp/workbench/welder/WelderTestSuite.scala
@@ -1,5 +1,6 @@
 package org.broadinstitute.dsp.workbench.welder
 
+import cats.Eq
 import cats.effect.{ContextShift, IO, Timer}
 import io.chrisdavenport.linebacker.Linebacker
 import io.chrisdavenport.log4cats.Logger
@@ -19,5 +20,13 @@ trait WelderTestSuite extends Matchers with ScalaCheckPropertyChecks with Config
   implicit val unsafeLogger: Logger[IO] = Slf4jLogger.getLogger[IO]
 
   implicit override val generatorDrivenConfig: PropertyCheckConfiguration = PropertyCheckConfiguration(minSuccessful = 3)
+
+  // Regex's equals doesn't compare Regex as expected. Hence, we define Eq[StorageLink] when we need to check equality of two StorageLink
+  implicit val storageLinkEq: Eq[StorageLink] = Eq.instance{ (s1, s2) =>
+    s1.pattern.pattern.pattern == s2.pattern.pattern.pattern &&
+    s1.localBaseDirectory == s2.localBaseDirectory &&
+    s1.localSafeModeBaseDirectory == s2.localSafeModeBaseDirectory &&
+    s1.cloudStorageDirectory == s2.cloudStorageDirectory
+  }
 }
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,7 +5,7 @@ object Dependencies {
   val http4sVersion = "0.20.3"
   val grpcCoreVersion = "1.17.1"
   val scalaTestVersion = "3.0.8"
-  val workbenchGoogle2V = "0.5-40c9ae6"
+  val workbenchGoogle2V = "0.5-a1f857c-SNAP"
 
   val common = List(
     "com.github.pureconfig" %% "pureconfig" % "0.11.0",

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,7 +5,7 @@ object Dependencies {
   val http4sVersion = "0.20.3"
   val grpcCoreVersion = "1.17.1"
   val scalaTestVersion = "3.0.8"
-  val workbenchGoogle2V = "0.5-a1f857c-SNAP"
+  val workbenchGoogle2V = "0.5-3fa06b5"
 
   val common = List(
     "com.github.pureconfig" %% "pureconfig" % "0.11.0",
@@ -24,7 +24,7 @@ object Dependencies {
     "org.scalacheck" %% "scalacheck" % "1.14.0" % "test",
     "ca.mrvisser" %% "sealerate" % "0.0.5",
     "io.chrisdavenport" %% "linebacker" % "0.2.1",
-    "com.google.cloud" % "google-cloud-nio" % "0.97.0-alpha" % "test"
+    "com.google.cloud" % "google-cloud-nio" % "0.101.0-alpha" % "test"
   )
 
   val server = common ++ List(

--- a/server/src/main/resources/reference.conf
+++ b/server/src/main/resources/reference.conf
@@ -8,3 +8,4 @@ object-service {
 }
 clean-up-lock-interval = 7 minutes
 flush-cache-interval = 10 minutes
+sync-cloud-storage-directory-interval = 15 minutes

--- a/server/src/main/scala/org/broadinstitute/dsp/workbench/welder/server/Config.scala
+++ b/server/src/main/scala/org/broadinstitute/dsp/workbench/welder/server/Config.scala
@@ -31,6 +31,7 @@ final case class AppConfig(
     serverPort: Int,
     cleanUpLockInterval: FiniteDuration,
     flushCacheInterval: FiniteDuration,
+    syncCloudStorageDirectoryInterval: FiniteDuration,
     pathToStorageLinksJson: Path,
     pathToGcsMetadataJson: Path,
     objectService: ObjectServiceConfig

--- a/server/src/main/scala/org/broadinstitute/dsp/workbench/welder/server/Main.scala
+++ b/server/src/main/scala/org/broadinstitute/dsp/workbench/welder/server/Main.scala
@@ -61,10 +61,11 @@ object Main extends IOApp {
       implicit0(it: Linebacker[IO]) <- Stream.eval(Linebacker.bounded(Linebacker.fromExecutionContext[IO](blockingEc), 255))
       googleStorageService <- Stream.resource(GoogleStorageService.fromApplicationDefault())
     } yield {
-      val storageLinksService = StorageLinksService(storageLinksCache, appConfig.objectService.workingDirectory)
+      val metadataCacheAlg = new MetadataCacheInterp(metadataCache)
       val googleStorageAlg = GoogleStorageAlg.fromGoogle(GoogleStorageAlgConfig(appConfig.objectService.workingDirectory), googleStorageService)
+      val storageLinksService = StorageLinksService(storageLinksCache, googleStorageAlg, metadataCacheAlg, appConfig.objectService.workingDirectory)
       val storageLinkAlg = StorageLinksAlg.fromCache(storageLinksCache)
-      val objectService = ObjectService(appConfig.objectService, googleStorageAlg, blockingEc, storageLinkAlg, metadataCache)
+      val objectService = ObjectService(appConfig.objectService, googleStorageAlg, blockingEc, storageLinkAlg, metadataCacheAlg)
       val cacheService = CacheService(
         CachedServiceConfig(appConfig.pathToStorageLinksJson, appConfig.pathToGcsMetadataJson),
         storageLinksCache,

--- a/server/src/main/scala/org/broadinstitute/dsp/workbench/welder/server/Main.scala
+++ b/server/src/main/scala/org/broadinstitute/dsp/workbench/welder/server/Main.scala
@@ -31,18 +31,8 @@ object Main extends IOApp {
         blockingEc,
         metadata => List(metadata.localPath -> metadata)
       )
-      welderApp <- initWelderApp(appConfig, blockingEc, storageLinksCache, metadataCache)
-      serverStream = BlazeServerBuilder[IO].bindHttp(appConfig.serverPort, "0.0.0.0").withHttpApp(welderApp.service).serve
-      cleanUpCache = BackgroundTask.cleanUpLock(metadataCache, appConfig.cleanUpLockInterval)
-      flushCache = BackgroundTask.flushBothCache(
-        appConfig.flushCacheInterval,
-        appConfig.pathToStorageLinksJson,
-        appConfig.pathToGcsMetadataJson,
-        storageLinksCache,
-        metadataCache,
-        blockingEc
-      )
-      _ <- Stream(cleanUpCache, flushCache, serverStream.drain).covary[IO].parJoin(3)
+      streams <- initStreams(appConfig, blockingEc, storageLinksCache, metadataCache)
+      _ <- Stream.emits(streams).covary[IO].parJoin(streams.length)
     } yield ()
 
     app
@@ -54,9 +44,9 @@ object Main extends IOApp {
       .as(ExitCode.Success)
   }
 
-  def initWelderApp(appConfig: AppConfig, blockingEc: ExecutionContext, storageLinksCache: StorageLinksCache, metadataCache: MetadataCache)(
+  def initStreams(appConfig: AppConfig, blockingEc: ExecutionContext, storageLinksCache: StorageLinksCache, metadataCache: MetadataCache)(
       implicit logger: Logger[IO]
-  ): Stream[IO, WelderApp] =
+  ): Stream[IO, List[Stream[IO, Unit]]] =
     for {
       implicit0(it: Linebacker[IO]) <- Stream.eval(Linebacker.bounded(Linebacker.fromExecutionContext[IO](blockingEc), 255))
       googleStorageService <- Stream.resource(GoogleStorageService.fromApplicationDefault())
@@ -72,6 +62,16 @@ object Main extends IOApp {
         metadataCache,
         blockingEc
       )
-      WelderApp(objectService, storageLinksService, cacheService)
+      val welderApp = WelderApp(objectService, storageLinksService, cacheService)
+      val serverStream = BlazeServerBuilder[IO].bindHttp(appConfig.serverPort, "0.0.0.0").withHttpApp(welderApp.service).serve
+
+      val backGroundTaskConfig = BackgroundTaskConfig(appConfig.objectService.workingDirectory, appConfig.cleanUpLockInterval, appConfig.flushCacheInterval, appConfig.syncCloudStorageDirectoryInterval)
+      val backGroundTask = new BackgroundTask(backGroundTaskConfig, metadataCache, storageLinksCache, googleStorageAlg, metadataCacheAlg)
+      val flushCache = backGroundTask.flushBothCache(
+        appConfig.pathToStorageLinksJson,
+        appConfig.pathToGcsMetadataJson,
+        blockingEc
+      )
+      List(backGroundTask.cleanUpLock, flushCache, backGroundTask.syncCloudStorageDirectory, serverStream.drain)
     }
 }

--- a/server/src/main/scala/org/broadinstitute/dsp/workbench/welder/server/ObjectService.scala
+++ b/server/src/main/scala/org/broadinstitute/dsp/workbench/welder/server/ObjectService.scala
@@ -131,7 +131,8 @@ class ObjectService(
         updateMetadataResponse =>
           updateMetadataResponse match {
             case UpdateMetadataResponse.DirectMetadataUpdate => IO.unit
-            case UpdateMetadataResponse.ReUploadObject(generation, crc32c) => metadataCacheAlg.updateLocalFileStateCache(localPath, RemoteState(Some(lock), crc32c), generation)
+            case UpdateMetadataResponse.ReUploadObject(generation, crc32c) =>
+              metadataCacheAlg.updateLocalFileStateCache(localPath, RemoteState(Some(lock), crc32c), generation)
           }
       )
 
@@ -262,7 +263,7 @@ class ObjectService(
               IO.raiseError(InvalidLock(s"Local GCS metadata for ${req.localObjectPath} not found"))
           }
           _ <- googleStorageAlg.removeObject(gsPath, traceId, Some(generation)).compile.drain.void
-          _ <- metadataCacheAlg.removeCache(req.localObjectPath)// remove the object from cache
+          _ <- metadataCacheAlg.removeCache(req.localObjectPath) // remove the object from cache
         } yield ()
         Kleisli.liftF(res)
       }

--- a/server/src/main/scala/org/broadinstitute/dsp/workbench/welder/server/ObjectService.scala
+++ b/server/src/main/scala/org/broadinstitute/dsp/workbench/welder/server/ObjectService.scala
@@ -33,7 +33,7 @@ class ObjectService(
     googleStorageAlg: GoogleStorageAlg,
     blockingEc: ExecutionContext,
     storageLinksAlg: StorageLinksAlg,
-    metadataCache: MetadataCache
+    metadataCacheAlg: MetadataCacheAlg
 )(implicit cs: ContextShift[IO], timer: Timer[IO], logger: Logger[IO])
     extends Http4sDsl[IO] {
   val service: HttpRoutes[IO] = HttpRoutes.of[IO] {
@@ -75,7 +75,7 @@ class ObjectService(
             for {
               meta <- googleStorageAlg.gcsToLocalFile(localAbsolutePath, gsPath, traceId).last
               _ <- meta.fold[Stream[IO, Unit]](Stream.raiseError[IO](NotFoundException(s"${gsPath} not found")))(
-                m => Stream.eval(updateCache(entry.localObjectPath, m))
+                m => Stream.eval(metadataCacheAlg.updateCache(entry.localObjectPath, m))
               )
             } yield ()
         }
@@ -108,7 +108,7 @@ class ObjectService(
       res <- meta match {
         case Some(m) =>
           for {
-            _ <- updateRemoteStateCache(req.localObjectPath, RemoteState(m.lock, m.crc32c))
+            _ <- metadataCacheAlg.updateRemoteStateCache(req.localObjectPath, RemoteState(m.lock, m.crc32c))
             res <- m.lock match {
               case Some(lock) =>
                 if (lock.hashedLockedBy == hashedLockedByCurrentUser)
@@ -131,7 +131,7 @@ class ObjectService(
         updateMetadataResponse =>
           updateMetadataResponse match {
             case UpdateMetadataResponse.DirectMetadataUpdate => IO.unit
-            case UpdateMetadataResponse.ReUploadObject(generation, crc32c) => updateLocalFileStateCache(localPath, RemoteState(Some(lock), crc32c), generation)
+            case UpdateMetadataResponse.ReUploadObject(generation, crc32c) => metadataCacheAlg.updateLocalFileStateCache(localPath, RemoteState(Some(lock), crc32c), generation)
           }
       )
 
@@ -165,7 +165,7 @@ class ObjectService(
                 syncStatus <- if (calculatedCrc32c == crc32c) IO.pure(SyncStatus.Live)
                 else {
                   for {
-                    metaOpt <- metadataCache.get.map(_.get(req.localObjectPath))
+                    metaOpt <- metadataCacheAlg.getCache(req.localObjectPath)
                     loggingContext = MetaLoggingContext(traceId, "checkMetadata", context, metaOpt.flatMap(_.localFileGeneration), generation)
                     status <- metaOpt match {
                       case Some(meta) =>
@@ -190,7 +190,7 @@ class ObjectService(
                     }
                   } yield status
                 }
-                _ <- updateRemoteStateCache(req.localObjectPath, RemoteState(lock, crc32c))
+                _ <- metadataCacheAlg.updateRemoteStateCache(req.localObjectPath, RemoteState(lock, crc32c))
               } yield MetadataResponse.EditMode(syncStatus, lock.map(_.hashedLockedBy), generation, context.storageLink)
               Kleisli.liftF[IO, TraceId, MetadataResponse](res)
           }
@@ -208,7 +208,7 @@ class ObjectService(
       else {
         val localAbsolutePath = config.workingDirectory.resolve(req.localObjectPath.asPath)
         val res: IO[Unit] = for {
-          previousMeta <- metadataCache.get.map(_.get(req.localObjectPath))
+          previousMeta <- metadataCacheAlg.getCache(req.localObjectPath)
           gsPath = getGsPath(req.localObjectPath, context)
           now <- timer.clock.realTime(TimeUnit.MILLISECONDS)
           calculatedCrc32c <- Crc32c.calculateCrc32ForFile(localAbsolutePath, blockingEc)
@@ -251,7 +251,7 @@ class ObjectService(
       else {
         val gsPath = getGsPath(req.localObjectPath, context)
         val res = for {
-          previousMeta <- metadataCache.get.map(_.get(req.localObjectPath))
+          previousMeta <- metadataCacheAlg.getCache(req.localObjectPath)
           now <- timer.clock.realTime(TimeUnit.MILLISECONDS)
           generation <- previousMeta match {
             case Some(meta) =>
@@ -262,7 +262,7 @@ class ObjectService(
               IO.raiseError(InvalidLock(s"Local GCS metadata for ${req.localObjectPath} not found"))
           }
           _ <- googleStorageAlg.removeObject(gsPath, traceId, Some(generation)).compile.drain.void
-          _ <- metadataCache.modify(mp => (mp - req.localObjectPath, ())) // remove the object from cache
+          _ <- metadataCacheAlg.removeCache(req.localObjectPath)// remove the object from cache
         } yield ()
         Kleisli.liftF(res)
       }
@@ -272,7 +272,7 @@ class ObjectService(
     val lockMetadataToPush = lock.map(_.toMetadataMap).getOrElse(Map.empty)
     for {
       delocalizeResp <- googleStorageAlg.delocalize(localObjectPath, gsPath, generation, lockMetadataToPush, traceId)
-      _ <- updateLocalFileStateCache(localObjectPath, RemoteState(lock, delocalizeResp.crc32c), delocalizeResp.generation)
+      _ <- metadataCacheAlg.updateLocalFileStateCache(localObjectPath, RemoteState(lock, delocalizeResp.crc32c), delocalizeResp.generation)
     } yield ()
   }
 
@@ -286,30 +286,6 @@ class ObjectService(
         IO.unit
       else IO.raiseError(InvalidLock("Fail to delocalize due to lock expiration or lock held by someone else"))
     } yield ()
-
-  private def updateRemoteStateCache(localPath: RelativePath, remoteState: RemoteState): IO[Unit] =
-    metadataCache.modify { mp =>
-      val previousMeta = mp.get(localPath)
-      val newCache = mp + (localPath -> AdaptedGcsMetadataCache(localPath, remoteState, previousMeta.flatMap(_.localFileGeneration)))
-      (newCache, ())
-    }
-
-  private def updateLocalFileStateCache(localPath: RelativePath, remoteState: RemoteState, localFileGeneration: Long): IO[Unit] =
-    metadataCache.modify { mp =>
-      val previousMeta = mp.get(localPath)
-      val newCache = mp + (localPath -> AdaptedGcsMetadataCache(localPath, remoteState, Some(localFileGeneration)))
-      (newCache, ())
-    }
-
-  private def updateCache(localPath: RelativePath, adaptedGcsMetadata: AdaptedGcsMetadata): IO[Unit] =
-    metadataCache.modify { mp =>
-      val newCache = mp + (localPath -> AdaptedGcsMetadataCache(
-        localPath,
-        RemoteState(adaptedGcsMetadata.lock, adaptedGcsMetadata.crc32c),
-        Some(adaptedGcsMetadata.generation)
-      ))
-      (newCache, ())
-    }
 }
 
 object ObjectService {
@@ -318,12 +294,12 @@ object ObjectService {
       googleStorageAlg: GoogleStorageAlg,
       blockingEc: ExecutionContext,
       storageLinksAlg: StorageLinksAlg,
-      metadataCache: MetadataCache
+      metadataCacheAlg: MetadataCacheAlg
   )(
       implicit cs: ContextShift[IO],
       timer: Timer[IO],
       logger: Logger[IO]
-  ): ObjectService = new ObjectService(config, googleStorageAlg, blockingEc, storageLinksAlg, metadataCache)
+  ): ObjectService = new ObjectService(config, googleStorageAlg, blockingEc, storageLinksAlg, metadataCacheAlg)
 
   implicit val actionDecoder: Decoder[Action] = Decoder.decodeString.emap { str =>
     Action.stringToAction.get(str).toRight("invalid action")

--- a/server/src/main/scala/org/broadinstitute/dsp/workbench/welder/server/StorageLinksService.scala
+++ b/server/src/main/scala/org/broadinstitute/dsp/workbench/welder/server/StorageLinksService.scala
@@ -15,7 +15,6 @@ import java.util.UUID
 import cats.implicits._
 import io.chrisdavenport.log4cats.Logger
 import org.broadinstitute.dsde.workbench.model.TraceId
-import org.broadinstitute.dsp.workbench.welder.LocalDirectory.LocalBaseDirectory
 
 class StorageLinksService(storageLinks: StorageLinksCache, googleStorageAlg: GoogleStorageAlg, metadataCacheAlg: MetadataCacheAlg, workingDirectory: Path)(
     implicit logger: Logger[IO]
@@ -50,7 +49,7 @@ class StorageLinksService(storageLinks: StorageLinksCache, googleStorageAlg: Goo
       }
       _ <- initializeDirectories(storageLink)
       _ <- (googleStorageAlg
-        .localizeCloudDirectory(storageLink.localBaseDirectory.asInstanceOf[LocalBaseDirectory], storageLink.cloudStorageDirectory, workingDirectory, traceId)
+        .localizeCloudDirectory(storageLink.localBaseDirectory.path, storageLink.cloudStorageDirectory, workingDirectory, traceId)
         .through(metadataCacheAlg.updateCachePipe))
         .compile
         .drain

--- a/server/src/main/scala/org/broadinstitute/dsp/workbench/welder/server/StorageLinksService.scala
+++ b/server/src/main/scala/org/broadinstitute/dsp/workbench/welder/server/StorageLinksService.scala
@@ -49,7 +49,7 @@ class StorageLinksService(storageLinks: StorageLinksCache, googleStorageAlg: Goo
       }
       _ <- initializeDirectories(storageLink)
       _ <- (googleStorageAlg
-        .localizeCloudDirectory(storageLink.localBaseDirectory.path, storageLink.cloudStorageDirectory, workingDirectory, traceId)
+        .localizeCloudDirectory(storageLink.localBaseDirectory.path, storageLink.cloudStorageDirectory, workingDirectory, storageLink.pattern, traceId)
         .through(metadataCacheAlg.updateCachePipe))
         .compile
         .drain

--- a/server/src/main/scala/org/broadinstitute/dsp/workbench/welder/server/StorageLinksService.scala
+++ b/server/src/main/scala/org/broadinstitute/dsp/workbench/welder/server/StorageLinksService.scala
@@ -10,11 +10,14 @@ import org.http4s.circe.CirceEntityDecoder._
 import org.http4s.circe.CirceEntityEncoder._
 import org.http4s.dsl.Http4sDsl
 import java.nio.file.Path
+import java.util.UUID
 
 import cats.implicits._
 import io.chrisdavenport.log4cats.Logger
+import org.broadinstitute.dsde.workbench.model.TraceId
+import org.broadinstitute.dsp.workbench.welder.LocalDirectory.LocalBaseDirectory
 
-class StorageLinksService(storageLinks: StorageLinksCache, workingDirectory: Path)(
+class StorageLinksService(storageLinks: StorageLinksCache, googleStorageAlg: GoogleStorageAlg, metadataCacheAlg: MetadataCacheAlg, workingDirectory: Path)(
     implicit logger: Logger[IO]
 ) extends Http4sDsl[IO] {
   val service: HttpRoutes[IO] = HttpRoutes.of[IO] {
@@ -40,11 +43,24 @@ class StorageLinksService(storageLinks: StorageLinksCache, workingDirectory: Pat
   //note: first param in the modify is the thing to do, second param is the value to return
   def createStorageLink(storageLink: StorageLink): IO[StorageLink] =
     for {
+      traceId <- IO(TraceId(UUID.randomUUID()))
       link <- storageLinks.modify { links =>
         val toAdd = List(storageLink.localBaseDirectory.path -> storageLink, storageLink.localSafeModeBaseDirectory.path -> storageLink).toMap
         (links ++ toAdd, storageLink)
       }
       _ <- initializeDirectories(storageLink)
+      _ <- (googleStorageAlg
+        .localizeCloudDirectory(
+          storageLink.localBaseDirectory.asInstanceOf[LocalBaseDirectory],
+          storageLink.cloudStorageDirectory,
+          workingDirectory,
+          traceId).through(metadataCacheAlg.updateCachePipe)).compile.drain.runAsync {
+        cb =>
+          cb match {
+            case Left(r) => logger.warn(s"fail to download files under ${storageLink.cloudStorageDirectory} when creating storagelink")
+            case Right(()) => IO.unit
+          }
+      }.toIO
     } yield link
 
   //returns whether the directories exist at the end of execution
@@ -86,8 +102,8 @@ class StorageLinksService(storageLinks: StorageLinksCache, workingDirectory: Pat
 final case class StorageLinks(storageLinks: Set[StorageLink])
 
 object StorageLinksService {
-  def apply(storageLinks: StorageLinksCache, workingDirectory: Path)(implicit logger: Logger[IO]): StorageLinksService =
-    new StorageLinksService(storageLinks, workingDirectory)
+  def apply(storageLinks: StorageLinksCache, googleStorageAlg: GoogleStorageAlg, metadataCacheAlg: MetadataCacheAlg, workingDirectory: Path)(implicit logger: Logger[IO]): StorageLinksService =
+    new StorageLinksService(storageLinks, googleStorageAlg, metadataCacheAlg, workingDirectory)
 
   implicit val storageLinksEncoder: Encoder[StorageLinks] = Encoder.forProduct1(
     "storageLinks"

--- a/server/src/test/scala/org/broadinstitute/dsp/workbench/welder/server/CacheServiceSpec.scala
+++ b/server/src/test/scala/org/broadinstitute/dsp/workbench/welder/server/CacheServiceSpec.scala
@@ -11,14 +11,13 @@ import org.broadinstitute.dsp.workbench.welder.Generators._
 import org.broadinstitute.dsp.workbench.welder.JsonCodec._
 import org.http4s.{Method, Request, Status, Uri}
 import org.scalatest.{FlatSpec, Matchers}
-
 import scala.concurrent.ExecutionContext.global
 
 class CacheServiceSpec extends FlatSpec with Matchers with WelderTestSuite {
   val config = CachedServiceConfig(Paths.get("/tmp/storagelinks.json"), Paths.get("/tmp/metadata.json"))
 
 
-  "CacheService" should "return service status" in {
+  "CacheService" should "return flush cache" in {
     forAll {
       (localPath: RelativePath, storageLink: StorageLink) =>
         val metadata = AdaptedGcsMetadataCache(localPath, RemoteState(None, Crc32("sfds")), None)
@@ -38,7 +37,8 @@ class CacheServiceSpec extends FlatSpec with Matchers with WelderTestSuite {
           _ <- IO((new File(config.metadataCachePath.toString)).delete())
         } yield {
           resp.get.status shouldBe Status.NoContent
-          storageLinkResult shouldBe(List(storageLink))
+
+          assert(storageLinkEq.eqv(storageLinkResult(0), (storageLink)))
           metadataResult shouldBe(List(metadata))
         }
       res.unsafeRunSync()

--- a/server/src/test/scala/org/broadinstitute/dsp/workbench/welder/server/ConfigSpec.scala
+++ b/server/src/test/scala/org/broadinstitute/dsp/workbench/welder/server/ConfigSpec.scala
@@ -11,7 +11,7 @@ class ConfigSpec extends FlatSpec with Matchers {
   "Config" should "read configuration correctly" in {
     val config = Config.appConfig
     val objectServiceConfig = ObjectServiceConfig(Paths.get("/work"), WorkbenchEmail("fake@gmail.com"), 3 minutes)
-    val expectedConfig = AppConfig(8080, 7 minutes, 10 minutes, Paths.get("/work/.welder/storage_links.json"), Paths.get("/work/.welder/gcs_metadata.json"), objectServiceConfig)
+    val expectedConfig = AppConfig(8080, 7 minutes, 10 minutes, 15 minutes, Paths.get("/work/.welder/storage_links.json"), Paths.get("/work/.welder/gcs_metadata.json"), objectServiceConfig)
     config shouldBe Right(expectedConfig)
   }
 }

--- a/server/src/test/scala/org/broadinstitute/dsp/workbench/welder/server/ObjectServiceSpec.scala
+++ b/server/src/test/scala/org/broadinstitute/dsp/workbench/welder/server/ObjectServiceSpec.scala
@@ -456,7 +456,7 @@ class ObjectServiceSpec extends FlatSpec with WelderTestSuite {
             IO(generation shouldBe(111L)) >>
             IO(DelocalizeResponse(112L, Crc32("newHash")))
           }
-          override def localizeCloudDirectory(localBaseDirectory: LocalBaseDirectory, cloudStorageDirectory: CloudStorageDirectory, workingDir: Path, traceId: TraceId): Stream[IO, AdaptedGcsMetadataCache] = Stream.empty
+          override def localizeCloudDirectory(localBaseDirectory: RelativePath, cloudStorageDirectory: CloudStorageDirectory, workingDir: Path, traceId: TraceId): Stream[IO, AdaptedGcsMetadataCache] = Stream.empty
         }
         val metadataCacheAlg = new MetadataCacheInterp(metaCache)
         val objectService = ObjectService(objectServiceConfig, storageAlg, global, storageLinkAlg, metadataCacheAlg)
@@ -500,7 +500,7 @@ class ObjectServiceSpec extends FlatSpec with WelderTestSuite {
         val storageLinkAlg = StorageLinksAlg.fromCache(storageLinksCache)
 
         val storageAlg = new GoogleStorageAlg {
-          override def localizeCloudDirectory(localBaseDirectory: LocalBaseDirectory, cloudStorageDirectory: CloudStorageDirectory, workingDir: Path, traceId: TraceId): Stream[IO, AdaptedGcsMetadataCache] = Stream.empty
+          override def localizeCloudDirectory(localBaseDirectory: RelativePath, cloudStorageDirectory: CloudStorageDirectory, workingDir: Path, traceId: TraceId): Stream[IO, AdaptedGcsMetadataCache] = Stream.empty
           override def updateMetadata(gsPath: GsPath, traceId: TraceId, metadata: Map[String, String]): IO[UpdateMetadataResponse] = IO.pure(UpdateMetadataResponse.DirectMetadataUpdate)
           override def retrieveAdaptedGcsMetadata(localPath: RelativePath, gsPath: GsPath, traceId: TraceId): IO[Option[AdaptedGcsMetadata]] = ???
           override def removeObject(gsPath: GsPath, traceId: TraceId, generation: Option[Long]): Stream[IO, RemoveObjectResult] = ???
@@ -541,7 +541,7 @@ class ObjectServiceSpec extends FlatSpec with WelderTestSuite {
         val localPath = s"${localBaseDirectory.path.toString}/test.ipynb"
         val bodyBytes = "this is great!".getBytes("UTF-8")
         val storageAlg = new GoogleStorageAlg {
-          override def localizeCloudDirectory(localBaseDirectory: LocalBaseDirectory, cloudStorageDirectory: CloudStorageDirectory, workingDir: Path, traceId: TraceId): Stream[IO, AdaptedGcsMetadataCache] = Stream.empty
+          override def localizeCloudDirectory(localBaseDirectory: RelativePath, cloudStorageDirectory: CloudStorageDirectory, workingDir: Path, traceId: TraceId): Stream[IO, AdaptedGcsMetadataCache] = Stream.empty
           override def updateMetadata(gsPath: GsPath, traceId: TraceId, metadata: Map[String, String]): IO[UpdateMetadataResponse] = IO.pure(UpdateMetadataResponse.DirectMetadataUpdate)
           override def retrieveAdaptedGcsMetadata(localPath: RelativePath, gsPath: GsPath, traceId: TraceId): IO[Option[AdaptedGcsMetadata]] = ???
           override def removeObject(gsPath: GsPath, traceId: TraceId, generation: Option[Long]): Stream[IO, RemoveObjectResult] = ???
@@ -815,7 +815,7 @@ class ObjectServiceSpec extends FlatSpec with WelderTestSuite {
           override def removeObject(gsPath: GsPath, traceId: TraceId, generation: Option[Long]): Stream[IO, RemoveObjectResult] = ???
           override def gcsToLocalFile(localAbsolutePath: Path, gsPath: GsPath, traceId: TraceId): Stream[IO, AdaptedGcsMetadata] = ???
           override def delocalize(localObjectPath: RelativePath, gsPath: GsPath, generation: Long, userDefinedMeta: Map[String, String], traceId: TraceId): IO[DelocalizeResponse] = ???
-          override def localizeCloudDirectory(localBaseDirectory: LocalBaseDirectory, cloudStorageDirectory: CloudStorageDirectory, workingDir: Path, traceId: TraceId): Stream[IO, AdaptedGcsMetadataCache] = Stream.empty
+          override def localizeCloudDirectory(localBaseDirectory: RelativePath, cloudStorageDirectory: CloudStorageDirectory, workingDir: Path, traceId: TraceId): Stream[IO, AdaptedGcsMetadataCache] = Stream.empty
         }
         val metaCache = Ref.unsafe[IO, Map[RelativePath, AdaptedGcsMetadataCache]](Map.empty)
         val objectService = initObjectServiceWithMetadataCacheAndGoogleStorageAlg(Map(storageLink.localBaseDirectory.path -> storageLink), metaCache, googleStorageAlg)
@@ -858,7 +858,7 @@ class ObjectServiceSpec extends FlatSpec with WelderTestSuite {
           override def removeObject(gsPath: GsPath, traceId: TraceId, generation: Option[Long]): Stream[IO, RemoveObjectResult] = ???
           override def gcsToLocalFile(localAbsolutePath: Path, gsPath: GsPath, traceId: TraceId): Stream[IO, AdaptedGcsMetadata] = ???
           override def delocalize(localObjectPath: RelativePath, gsPath: GsPath, generation: Long, userDefinedMeta: Map[String, String], traceId: TraceId): IO[DelocalizeResponse] = ???
-          override def localizeCloudDirectory(localBaseDirectory: LocalBaseDirectory, cloudStorageDirectory: CloudStorageDirectory, workingDir: Path, traceId: TraceId): Stream[IO, AdaptedGcsMetadataCache] = Stream.empty
+          override def localizeCloudDirectory(localBaseDirectory: RelativePath, cloudStorageDirectory: CloudStorageDirectory, workingDir: Path, traceId: TraceId): Stream[IO, AdaptedGcsMetadataCache] = Stream.empty
         }
         val objectService = initObjectServiceWithGoogleStorageAlg(Map(storageLink.localBaseDirectory.path -> storageLink), Map.empty, googleStorageAlg)
         val localAbsolutePath = Paths.get(s"/tmp/${storageLink.localBaseDirectory.path.toString}/test.ipynb")
@@ -900,7 +900,7 @@ class ObjectServiceSpec extends FlatSpec with WelderTestSuite {
           override def removeObject(gsPath: GsPath, traceId: TraceId, generation: Option[Long]): Stream[IO, RemoveObjectResult] = ???
           override def gcsToLocalFile(localAbsolutePath: Path, gsPath: GsPath, traceId: TraceId): Stream[IO, AdaptedGcsMetadata] = ???
           override def delocalize(localObjectPath: RelativePath, gsPath: GsPath, generation: Long, userDefinedMeta: Map[String, String], traceId: TraceId): IO[DelocalizeResponse] = ???
-          override def localizeCloudDirectory(localBaseDirectory: LocalBaseDirectory, cloudStorageDirectory: CloudStorageDirectory, workingDir: Path, traceId: TraceId): Stream[IO, AdaptedGcsMetadataCache] = Stream.empty
+          override def localizeCloudDirectory(localBaseDirectory: RelativePath, cloudStorageDirectory: CloudStorageDirectory, workingDir: Path, traceId: TraceId): Stream[IO, AdaptedGcsMetadataCache] = Stream.empty
         }
         val metaCache = Ref.unsafe[IO, Map[RelativePath, AdaptedGcsMetadataCache]](Map.empty)
         val objectService = initObjectServiceWithMetadataCacheAndGoogleStorageAlg(Map(storageLink.localBaseDirectory.path -> storageLink), metaCache, googleStorageAlg)

--- a/server/src/test/scala/org/broadinstitute/dsp/workbench/welder/server/StorageLinksApiServiceSpec.scala
+++ b/server/src/test/scala/org/broadinstitute/dsp/workbench/welder/server/StorageLinksApiServiceSpec.scala
@@ -26,7 +26,7 @@ class StorageLinksApiServiceSpec extends FlatSpec with WelderTestSuite {
     override def removeObject(gsPath: GsPath, traceId: TraceId, generation: Option[Long]): Stream[IO, RemoveObjectResult] = ???
     override def gcsToLocalFile(localAbsolutePath: Path, gsPath: GsPath, traceId: TraceId): Stream[IO, AdaptedGcsMetadata] = ???
     override def delocalize(localObjectPath: RelativePath, gsPath: GsPath, generation: Long, userDefinedMeta: Map[String, String], traceId: TraceId): IO[DelocalizeResponse] = ???
-    override def localizeCloudDirectory(localBaseDirectory: LocalBaseDirectory, cloudStorageDirectory: CloudStorageDirectory, workingDir: Path, traceId: TraceId): Stream[IO, AdaptedGcsMetadataCache] = Stream.empty
+    override def localizeCloudDirectory(localBaseDirectory: RelativePath, cloudStorageDirectory: CloudStorageDirectory, workingDir: Path, traceId: TraceId): Stream[IO, AdaptedGcsMetadataCache] = Stream.empty
   }
   val metadataCacheAlg = new MetadataCacheInterp(Ref.unsafe[IO, Map[RelativePath, AdaptedGcsMetadataCache]](Map.empty))
   val storageLinksService = StorageLinksService(storageLinks, googleStorageAlg, metadataCacheAlg, workingDirectory)

--- a/server/src/test/scala/org/broadinstitute/dsp/workbench/welder/server/StorageLinksApiServiceSpec.scala
+++ b/server/src/test/scala/org/broadinstitute/dsp/workbench/welder/server/StorageLinksApiServiceSpec.scala
@@ -1,15 +1,18 @@
 package org.broadinstitute.dsp.workbench.welder
 package server
 
-import java.nio.file.Paths
+import java.nio.file.{Path, Paths}
 
 import cats.effect.IO
 import cats.effect.concurrent.Ref
 import cats.implicits._
-import fs2.text
+import fs2.{Stream, text}
 import io.circe.{Json, parser}
+import org.broadinstitute.dsde.workbench.google2.RemoveObjectResult
+import org.broadinstitute.dsde.workbench.model.TraceId
 import org.broadinstitute.dsde.workbench.model.google.GcsBucketName
 import org.broadinstitute.dsp.workbench.welder.LocalDirectory.{LocalBaseDirectory, LocalSafeBaseDirectory}
+import org.broadinstitute.dsp.workbench.welder.SourceUri.GsPath
 import org.http4s.circe.CirceEntityEncoder._
 import org.http4s.{Method, Request, Status, Uri}
 import org.scalatest.FlatSpec
@@ -17,7 +20,16 @@ import org.scalatest.FlatSpec
 class StorageLinksApiServiceSpec extends FlatSpec with WelderTestSuite {
   val storageLinks = Ref.unsafe[IO, Map[RelativePath, StorageLink]](Map.empty)
   val workingDirectory = Paths.get("/tmp")
-  val storageLinksService = StorageLinksService(storageLinks, workingDirectory)
+  val googleStorageAlg = new GoogleStorageAlg {
+    override def updateMetadata(gsPath: GsPath, traceId: TraceId, metadata: Map[String, String]): IO[UpdateMetadataResponse] = IO.pure(UpdateMetadataResponse.DirectMetadataUpdate)
+    override def retrieveAdaptedGcsMetadata(localPath: RelativePath, gsPath: GsPath, traceId: TraceId): IO[Option[AdaptedGcsMetadata]] = ???
+    override def removeObject(gsPath: GsPath, traceId: TraceId, generation: Option[Long]): Stream[IO, RemoveObjectResult] = ???
+    override def gcsToLocalFile(localAbsolutePath: Path, gsPath: GsPath, traceId: TraceId): Stream[IO, AdaptedGcsMetadata] = ???
+    override def delocalize(localObjectPath: RelativePath, gsPath: GsPath, generation: Long, userDefinedMeta: Map[String, String], traceId: TraceId): IO[DelocalizeResponse] = ???
+    override def localizeCloudDirectory(localBaseDirectory: LocalBaseDirectory, cloudStorageDirectory: CloudStorageDirectory, workingDir: Path, traceId: TraceId): Stream[IO, AdaptedGcsMetadataCache] = Stream.empty
+  }
+  val metadataCacheAlg = new MetadataCacheInterp(Ref.unsafe[IO, Map[RelativePath, AdaptedGcsMetadataCache]](Map.empty))
+  val storageLinksService = StorageLinksService(storageLinks, googleStorageAlg, metadataCacheAlg, workingDirectory)
   val cloudStorageDirectory = CloudStorageDirectory(GcsBucketName("foo"), Some(BlobPath("bar")))
   val baseDir = RelativePath(Paths.get("foo"))
   val baseSafeDir = RelativePath(Paths.get("bar"))

--- a/server/src/test/scala/org/broadinstitute/dsp/workbench/welder/server/StorageLinksServiceSpec.scala
+++ b/server/src/test/scala/org/broadinstitute/dsp/workbench/welder/server/StorageLinksServiceSpec.scala
@@ -53,29 +53,6 @@ class StorageLinksServiceSpec extends FlatSpec with WelderTestSuite {
     assert(listResult.storageLinks equals Set(linkToAdd))
   }
 
-//  it should "download files from CloudStorageDirectory recursively" in {
-//    val bucketName = genGcsBucketName.sample.get
-//    val prefix = "samePrefix"
-//    val blobNameWithPrefix = Gen.listOfN(4, genGcsBlobName).sample.get.map(x => GcsBlobName(s"$prefix/${x.value}"))
-//    val blobNames = Gen.listOfN(5, genGcsBlobName).sample.get
-//    val allObjects = blobNameWithPrefix ++ blobNames
-//    val objectBody = genGcsObjectBody.sample.get
-//    val emptyStorageLinksCache = Ref.unsafe[IO, Map[RelativePath, StorageLink]](Map.empty)
-//    val storageLinksService = StorageLinksService(emptyStorageLinksCache, googleStorageAlg, metadataCacheAlg, workingDirectory)
-//    val cloudStorageDirectory = CloudStorageDirectory(bucketName, Some(BlobPath(prefix)))
-//
-//    val linkToAdd = StorageLink(baseDir, baseSafeDir, cloudStorageDirectory, "*")
-//    val res = for {
-//      _ <- allObjects.parTraverse(obj => localStorage.createBlob(bucketName, obj, objectBody, objectType).compile.drain)
-//      _ = println(s"allfiles ${allObjects}")
-//      _ <- storageLinksService.createStorageLink(linkToAdd)
-//    } yield {
-//      val allFiles = allObjects.map(blobName => workingDirectory.resolve(Paths.get(prefix).relativize(Paths.get(blobName.value))))
-//      allFiles.forall(_.toFile.exists()) shouldBe true
-//    }
-//    res.unsafeRunSync()
-//  }
-
   it should "initialize directories" in {
     val emptyStorageLinksCache = Ref.unsafe[IO, Map[RelativePath, StorageLink]](Map.empty)
     val storageLinksService = StorageLinksService(emptyStorageLinksCache, googleStorageAlg, metadataCacheAlg, workingDirectory)

--- a/server/src/test/scala/org/broadinstitute/dsp/workbench/welder/server/StorageLinksServiceSpec.scala
+++ b/server/src/test/scala/org/broadinstitute/dsp/workbench/welder/server/StorageLinksServiceSpec.scala
@@ -24,7 +24,7 @@ class StorageLinksServiceSpec extends FlatSpec with WelderTestSuite {
     override def removeObject(gsPath: GsPath, traceId: TraceId, generation: Option[Long]): Stream[IO, RemoveObjectResult] = ???
     override def gcsToLocalFile(localAbsolutePath: Path, gsPath: GsPath, traceId: TraceId): Stream[IO, AdaptedGcsMetadata] = ???
     override def delocalize(localObjectPath: RelativePath, gsPath: GsPath, generation: Long, userDefinedMeta: Map[String, String], traceId: TraceId): IO[DelocalizeResponse] = ???
-    override def localizeCloudDirectory(localBaseDirectory: LocalBaseDirectory, cloudStorageDirectory: CloudStorageDirectory, workingDir: Path, traceId: TraceId): Stream[IO, AdaptedGcsMetadataCache] = Stream.empty
+    override def localizeCloudDirectory(localBaseDirectory: RelativePath, cloudStorageDirectory: CloudStorageDirectory, workingDir: Path, traceId: TraceId): Stream[IO, AdaptedGcsMetadataCache] = Stream.empty
   }
   val emptyMetadataCache = Ref.unsafe[IO, Map[RelativePath, AdaptedGcsMetadataCache]](Map.empty)
   val metadataCacheAlg = new MetadataCacheInterp(emptyMetadataCache)

--- a/server/src/test/scala/org/broadinstitute/dsp/workbench/welder/server/StorageLinksServiceSpec.scala
+++ b/server/src/test/scala/org/broadinstitute/dsp/workbench/welder/server/StorageLinksServiceSpec.scala
@@ -1,28 +1,38 @@
 package org.broadinstitute.dsp.workbench.welder
 package server
 
-import java.nio.file.Paths
+import java.nio.file.{Path, Paths}
 
 import cats.effect.IO
 import cats.effect.concurrent.Ref
-import io.chrisdavenport.log4cats.Logger
-import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
+import fs2.Stream
+import org.broadinstitute.dsde.workbench.google2.RemoveObjectResult
+import org.broadinstitute.dsde.workbench.model.TraceId
 import org.broadinstitute.dsde.workbench.model.google.GcsBucketName
 import org.broadinstitute.dsp.workbench.welder.LocalDirectory.{LocalBaseDirectory, LocalSafeBaseDirectory}
-import org.scalatest.{FlatSpec, Matchers}
+import org.broadinstitute.dsp.workbench.welder.SourceUri.GsPath
+import org.scalatest.FlatSpec
 
-class StorageLinksServiceSpec extends FlatSpec with Matchers {
-  implicit val unsafeLogger: Logger[IO] = Slf4jLogger.getLogger[IO]
+class StorageLinksServiceSpec extends FlatSpec with WelderTestSuite {
   val cloudStorageDirectory = CloudStorageDirectory(GcsBucketName("foo"), Some(BlobPath("bar/baz.zip")))
   val baseDir = LocalBaseDirectory(RelativePath(Paths.get("foo")))
   val baseSafeDir = LocalSafeBaseDirectory(RelativePath(Paths.get("bar")))
 
+  val googleStorageAlg = new GoogleStorageAlg {
+    override def updateMetadata(gsPath: GsPath, traceId: TraceId, metadata: Map[String, String]): IO[UpdateMetadataResponse] = IO.pure(UpdateMetadataResponse.DirectMetadataUpdate)
+    override def retrieveAdaptedGcsMetadata(localPath: RelativePath, gsPath: GsPath, traceId: TraceId): IO[Option[AdaptedGcsMetadata]] = ???
+    override def removeObject(gsPath: GsPath, traceId: TraceId, generation: Option[Long]): Stream[IO, RemoveObjectResult] = ???
+    override def gcsToLocalFile(localAbsolutePath: Path, gsPath: GsPath, traceId: TraceId): Stream[IO, AdaptedGcsMetadata] = ???
+    override def delocalize(localObjectPath: RelativePath, gsPath: GsPath, generation: Long, userDefinedMeta: Map[String, String], traceId: TraceId): IO[DelocalizeResponse] = ???
+    override def localizeCloudDirectory(localBaseDirectory: LocalBaseDirectory, cloudStorageDirectory: CloudStorageDirectory, workingDir: Path, traceId: TraceId): Stream[IO, AdaptedGcsMetadataCache] = Stream.empty
+  }
+  val emptyMetadataCache = Ref.unsafe[IO, Map[RelativePath, AdaptedGcsMetadataCache]](Map.empty)
+  val metadataCacheAlg = new MetadataCacheInterp(emptyMetadataCache)
   val workingDirectory = Paths.get("/tmp")
 
-  //TODO: remove boilerplate at the top of each test
   "StorageLinksService" should "create a storage link" in {
     val emptyStorageLinksCache = Ref.unsafe[IO, Map[RelativePath, StorageLink]](Map.empty)
-    val storageLinksService = StorageLinksService(emptyStorageLinksCache, workingDirectory)
+    val storageLinksService = StorageLinksService(emptyStorageLinksCache, googleStorageAlg, metadataCacheAlg, workingDirectory)
 
     val linkToAdd = StorageLink(baseDir, baseSafeDir, cloudStorageDirectory, ".zip")
 
@@ -32,7 +42,7 @@ class StorageLinksServiceSpec extends FlatSpec with Matchers {
 
   it should "not create duplicate storage links" in {
     val emptyStorageLinksCache = Ref.unsafe[IO, Map[RelativePath, StorageLink]](Map.empty)
-    val storageLinksService = StorageLinksService(emptyStorageLinksCache, workingDirectory)
+    val storageLinksService = StorageLinksService(emptyStorageLinksCache, googleStorageAlg, metadataCacheAlg, workingDirectory)
 
     val linkToAdd = StorageLink(baseDir, baseSafeDir, cloudStorageDirectory, ".zip")
 
@@ -43,9 +53,32 @@ class StorageLinksServiceSpec extends FlatSpec with Matchers {
     assert(listResult.storageLinks equals Set(linkToAdd))
   }
 
+//  it should "download files from CloudStorageDirectory recursively" in {
+//    val bucketName = genGcsBucketName.sample.get
+//    val prefix = "samePrefix"
+//    val blobNameWithPrefix = Gen.listOfN(4, genGcsBlobName).sample.get.map(x => GcsBlobName(s"$prefix/${x.value}"))
+//    val blobNames = Gen.listOfN(5, genGcsBlobName).sample.get
+//    val allObjects = blobNameWithPrefix ++ blobNames
+//    val objectBody = genGcsObjectBody.sample.get
+//    val emptyStorageLinksCache = Ref.unsafe[IO, Map[RelativePath, StorageLink]](Map.empty)
+//    val storageLinksService = StorageLinksService(emptyStorageLinksCache, googleStorageAlg, metadataCacheAlg, workingDirectory)
+//    val cloudStorageDirectory = CloudStorageDirectory(bucketName, Some(BlobPath(prefix)))
+//
+//    val linkToAdd = StorageLink(baseDir, baseSafeDir, cloudStorageDirectory, "*")
+//    val res = for {
+//      _ <- allObjects.parTraverse(obj => localStorage.createBlob(bucketName, obj, objectBody, objectType).compile.drain)
+//      _ = println(s"allfiles ${allObjects}")
+//      _ <- storageLinksService.createStorageLink(linkToAdd)
+//    } yield {
+//      val allFiles = allObjects.map(blobName => workingDirectory.resolve(Paths.get(prefix).relativize(Paths.get(blobName.value))))
+//      allFiles.forall(_.toFile.exists()) shouldBe true
+//    }
+//    res.unsafeRunSync()
+//  }
+
   it should "initialize directories" in {
     val emptyStorageLinksCache = Ref.unsafe[IO, Map[RelativePath, StorageLink]](Map.empty)
-    val storageLinksService = StorageLinksService(emptyStorageLinksCache, workingDirectory)
+    val storageLinksService = StorageLinksService(emptyStorageLinksCache, googleStorageAlg, metadataCacheAlg, workingDirectory)
 
     val safeAbsolutePath = workingDirectory.resolve(baseSafeDir.path.asPath)
     val editAbsolutePath = workingDirectory.resolve(baseDir.path.asPath)
@@ -68,7 +101,7 @@ class StorageLinksServiceSpec extends FlatSpec with Matchers {
 //  initializeDirectories
   it should "list storage links" in {
     val emptyStorageLinksCache = Ref.unsafe[IO, Map[RelativePath, StorageLink]](Map.empty)
-    val storageLinksService = StorageLinksService(emptyStorageLinksCache, workingDirectory)
+    val storageLinksService = StorageLinksService(emptyStorageLinksCache, googleStorageAlg, metadataCacheAlg, workingDirectory)
 
     val initialListResult = storageLinksService.getStorageLinks.unsafeRunSync()
     assert(initialListResult.storageLinks.isEmpty)
@@ -83,7 +116,7 @@ class StorageLinksServiceSpec extends FlatSpec with Matchers {
 
   it should "delete a storage link" in {
     val emptyStorageLinksCache = Ref.unsafe[IO, Map[RelativePath, StorageLink]](Map.empty)
-    val storageLinksService = StorageLinksService(emptyStorageLinksCache, workingDirectory)
+    val storageLinksService = StorageLinksService(emptyStorageLinksCache, googleStorageAlg, metadataCacheAlg, workingDirectory)
 
     val initialListResult = storageLinksService.getStorageLinks.unsafeRunSync()
     assert(initialListResult.storageLinks.isEmpty)
@@ -103,7 +136,7 @@ class StorageLinksServiceSpec extends FlatSpec with Matchers {
 
   it should "gracefully handle deleting a storage link that doesn't exist" in {
     val emptyStorageLinksCache = Ref.unsafe[IO, Map[RelativePath, StorageLink]](Map.empty)
-    val storageLinksService = StorageLinksService(emptyStorageLinksCache, workingDirectory)
+    val storageLinksService = StorageLinksService(emptyStorageLinksCache, googleStorageAlg, metadataCacheAlg, workingDirectory)
 
     val initialListResult = storageLinksService.getStorageLinks.unsafeRunSync()
     assert(initialListResult.storageLinks.isEmpty)


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-1098.

Note, with this change, `pattern` field in create storagelink api will be treated as Regex. Hence, `\.ipynb$` will need to be escaped in request, and call will fail if it's not escaped

* Make sure create storagelink api works as expected
```
gsutil ls -r gs://qi-test
gs://qi-test/test-1.txt
gs://qi-test/welder-test_nb.ipynb
gs://qi-test/welder-test_nb2.ipynb
gs://qi-test/test/:
gs://qi-test/test/
gs://qi-test/test/typeclasses.scala
gs://qi-test/test/welder-test_nb2.ipynb

gs://qi-test/test/test2Dir/:
gs://qi-test/test/test2Dir/
gs://qi-test/test/test2Dir/test-1.txt
```
```
➜  edit curl -vX POST --header 'Content-Type: application/json' --header 'Accept: application/json' localhost:8080/storageLinks -d '{"localBaseDirectory": "edit", "localSafeModeBaseDirectory": "safe", "cloudStorageDirectory": "gs://qi-test", "pattern": "\\.ipynb$" }'

Note: Unnecessary use of -X or --request, POST is already inferred.
*   Trying ::1...
* TCP_NODELAY set
* Connected to localhost (::1) port 8080 (#0)
> POST /storageLinks HTTP/1.1
> Host: localhost:8080
> User-Agent: curl/7.54.0
> Content-Type: application/json
> Accept: application/json
> Content-Length: 134
>
* upload completely sent off: 134 out of 134 bytes
< HTTP/1.1 200 OK
< Content-Type: application/json
< Date: Fri, 26 Jul 2019 18:11:58 GMT
< Content-Length: 126
<
* Connection #0 to host localhost left intact
{"localBaseDirectory":"edit","localSafeModeBaseDirectory":"safe","cloudStorageDirectory":"gs://qi-test","pattern":"\\.ipynb$"}%                                                                                                               ➜  edit cd ../
➜  /tmp tree edit
edit
├── test
│   └── welder-test_nb2.ipynb
├── welder-test_nb.ipynb
└── welder-test_nb2.ipynb

1 directory, 3 files
```