### PR TITLE
[IA-1652] Keep less log files on disk

### DIFF
--- a/server/src/main/resources/logback.xml
+++ b/server/src/main/resources/logback.xml
@@ -20,7 +20,7 @@
         <!-- or whenever the file size reaches 50MB -->
         <maxFileSize>50MB</maxFileSize>
       </timeBasedFileNamingAndTriggeringPolicy>
-      <!-- keep 30 days' worth of history -->
+      <!-- keep 3 days' worth of history -->
       <maxHistory>3</maxHistory>
     </rollingPolicy>
   </appender>

--- a/server/src/main/resources/logback.xml
+++ b/server/src/main/resources/logback.xml
@@ -21,7 +21,7 @@
         <maxFileSize>50MB</maxFileSize>
       </timeBasedFileNamingAndTriggeringPolicy>
       <!-- keep 30 days' worth of history -->
-      <maxHistory>30</maxHistory>
+      <maxHistory>7</maxHistory>
     </rollingPolicy>
   </appender>
 

--- a/server/src/main/resources/logback.xml
+++ b/server/src/main/resources/logback.xml
@@ -21,7 +21,7 @@
         <maxFileSize>50MB</maxFileSize>
       </timeBasedFileNamingAndTriggeringPolicy>
       <!-- keep 30 days' worth of history -->
-      <maxHistory>7</maxHistory>
+      <maxHistory>3</maxHistory>
     </rollingPolicy>
   </appender>
 


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-1652.

We stream log files to stackdriver anyway. We don't need to keep log files on disk for that long.