### PR TITLE
IA-1702 fix a bug where outdated workspace bucket is read

### DIFF
--- a/server/src/main/scala/org/broadinstitute/dsp/workbench/welder/server/StorageLinksService.scala
+++ b/server/src/main/scala/org/broadinstitute/dsp/workbench/welder/server/StorageLinksService.scala
@@ -91,7 +91,7 @@ class StorageLinksService(
       logger.info(s"writing ${destinationPath}") >> (Stream.emits(fileBody) through io.file.writeAll[IO](
         destinationPath,
         blocker,
-        List(StandardOpenOption.TRUNCATE_EXISTING)
+        List(StandardOpenOption.CREATE, StandardOpenOption.WRITE, StandardOpenOption.TRUNCATE_EXISTING)
       )).compile.drain // overwrite the file everytime storagelink is called since workspace bucket can be updated
 
     (writeToFile(editModeDestinationPath), writeToFile(safeModeDestinationPath)).parTupled.void


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-1702

I think what happened is workspace bucket was updated, but since welder never overwrites `.delocalize.json` file if it exists already, new workspace bucket was never reflected.


See log:
```

2020-02-20 15:55:07.750 EST
HTTP/1.1 POST /storageLinks Headers(Host: 127.0.0.1:8080, Authorization: <REDACTED>, sec-fetch-dest: empty, User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.100 Safari/537.36, Accept: */*, Origin: https://app.terra.bio, sec-fetch-site: cross-site, sec-fetch-mode: cors, Referer: https://app.terra.bio/, Accept-Encoding: gzip, deflate, br, Accept-Language: en-US, en;q=0.9, X-Cloud-Trace-Context: 7d9311ce2b9a0c2f41d8ae29049512f4/15842695380231557067, Via: 1.1 google, X-Forwarded-For: 69.173.127.108, 35.244.163.41, 35.191.3.87, 35.193.54.235, X-Forwarded-Proto: https, X-Forwarded-Host: notebooks.firecloud.org, app:8080, X-Forwarded-Server: leonardo.dsde-prod.broadinstitute.org, saturn-76b919b3-6bce-42e9-a12c-6d98f6a60578-m.c.broad-firecloud-dsde.internal, Content-Type: application/json, Connection: close, Content-Length: 299) body="{"localBaseDirectory":"An_ER_Pos_WAGLE-ms_2017_metadata_update_test2_MORGAN_backup copy/edit","localSafeModeBaseDirectory":"An_ER_Pos_WAGLE-ms_2017_metadata_update_test2_MORGAN_backup copy/safe","cloudStorageDirectory":"gs://fc-85f63371-58eb-4a65-a701-de0762adb46b/notebooks","pattern":".*\\.ipynb"}"

...

2020-02-20 16:34:55.552 EST
HTTP/1.1 POST /storageLinks Headers(Host: 127.0.0.1:8080, Authorization: <REDACTED>, sec-fetch-dest: empty, User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.100 Safari/537.36, Accept: */*, Origin: https://app.terra.bio, sec-fetch-site: cross-site, sec-fetch-mode: cors, Referer: https://app.terra.bio/, Accept-Encoding: gzip, deflate, br, Accept-Language: en-US, en;q=0.9, X-Cloud-Trace-Context: 361f1e1c905b82338ef49b75a5355919/3936346345496602470, Via: 1.1 google, X-Forwarded-For: 69.173.127.108, 35.244.163.41, 35.191.1.231, 35.193.54.235, X-Forwarded-Proto: https, X-Forwarded-Host: notebooks.firecloud.org, app:8080, X-Forwarded-Server: leonardo.dsde-prod.broadinstitute.org, saturn-76b919b3-6bce-42e9-a12c-6d98f6a60578-m.c.broad-firecloud-dsde.internal, Content-Type: application/json, Connection: close, Content-Length: 299) body="{"localBaseDirectory":"An_ER_Pos_WAGLE-ms_2017_metadata_update_test2_MORGAN_backup copy/edit","localSafeModeBaseDirectory":"An_ER_Pos_WAGLE-ms_2017_metadata_update_test2_MORGAN_backup copy/safe","cloudStorageDirectory":"gs://fc-620825f8-0ce3-4c8f-8c14-96daad4ae968/notebooks","pattern":".*\\.ipynb"}"
```

The second line has the right workspace bucket.