### PR TITLE
[IA-1709] Restart Welder if it crashes

### DIFF
--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -91,17 +91,10 @@ object Settings {
     )
 
   lazy val entrypoint = "/opt/docker/bin/entrypoint.sh"
+  lazy val entrypointLog = "/work/entrypoint.out"
 
   lazy val entrypointCmd =
-    s"""#!/bin/bash
-       |numask 002;
-       |until /opt/docker/bin/server; do
-       |  echo 'Welder crashed. Respawning..' >&2
-       |  sleep 1
-       |done""".stripMargin
-
-  lazy val entrypointTestCmd =
-    s"""'#!/bin/bash\\numask 002;\\nuntil /opt/docker/bin/server; do\\n\\techo '[$(date -u)] Welder crashed. Respawning..' >> /work/entrypoint.out\\n\\tsleep 1\\ndone'""".stripMargin
+    s"""'#!/bin/bash\\numask 002;\\necho '[$$(date -u)] Starting welder java process' >> $entrypointLog\\nuntil /opt/docker/bin/server; do\\n\\techo '[$$(date -u)] Welder crashed. Respawning..' >> $entrypointLog\\n\\tsleep 1\\ndone'""".stripMargin
 
   lazy val commonDockerSettings = List(
     maintainer := "workbench-interactive-analysis@broadinstitute.org",
@@ -114,7 +107,7 @@ object Settings {
     dockerCommands ++= List(
       // Change the default umask for welder to support R/W access to the shared volume
       Cmd("USER", "root"),
-      ExecCmd("RUN", "/bin/bash", "-c", s"echo $entrypointTestCmd > $entrypoint"),
+      ExecCmd("RUN", "/bin/bash", "-c", s"echo $entrypointCmd > $entrypoint"),
       Cmd("RUN", s"chown -R welder-user:users /opt/docker && chmod u+x,g+x $entrypoint"),
       Cmd("USER", (daemonUser in Docker).value)
     )

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -101,7 +101,7 @@ object Settings {
        |done""".stripMargin
 
   lazy val entrypointTestCmd =
-    s"""#!/bin/bash\\numask 002; until /opt/docker/bin/server; do\\n\\techo 'Welder crashed. Respawning..' >&2\\n\\tsleep 1\\ndone""".stripMargin
+    s"""'#!/bin/bash\\numask 002;\\necho 'This is coming from entrypoint'\\nuntil /opt/docker/bin/server; do\\n\\techo 'Welder crashed. Respawning..' >&2\\n\\tsleep 1\\ndone'""".stripMargin
 
   lazy val commonDockerSettings = List(
     maintainer := "workbench-interactive-analysis@broadinstitute.org",

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -101,7 +101,7 @@ object Settings {
        |done""".stripMargin
 
   lazy val entrypointTestCmd =
-    s"""'#!/bin/bash\\numask 002;\\necho 'This is coming from entrypoint' >> entrypoint.out\\nuntil /opt/docker/bin/server; do\\n\\techo 'Welder crashed. Respawning..' >> entrypoint.out\\n\\tsleep 1\\ndone'""".stripMargin
+    s"""'#!/bin/bash\\numask 002;\\necho 'This is coming from entrypoint' >> /work/entrypoint.out\\nuntil /opt/docker/bin/server; do\\n\\techo 'Welder crashed. Respawning..' >> /work/entrypoint.out\\n\\tsleep 1\\ndone'""".stripMargin
 
   lazy val commonDockerSettings = List(
     maintainer := "workbench-interactive-analysis@broadinstitute.org",

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -101,7 +101,7 @@ object Settings {
        |done""".stripMargin
 
   lazy val entrypointTestCmd =
-    s"""'#!/bin/bash\\numask 002;\\necho 'This is coming from entrypoint' >> /work/entrypoint.out\\nuntil /opt/docker/bin/server; do\\n\\techo 'Welder crashed. Respawning..' >> /work/entrypoint.out\\n\\tsleep 1\\ndone'""".stripMargin
+    s"""'#!/bin/bash\\numask 002;\\nuntil /opt/docker/bin/server; do\\n\\techo '[$(date -u)] Welder crashed. Respawning..' >> /work/entrypoint.out\\n\\tsleep 1\\ndone'""".stripMargin
 
   lazy val commonDockerSettings = List(
     maintainer := "workbench-interactive-analysis@broadinstitute.org",

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -101,7 +101,7 @@ object Settings {
        |done""".stripMargin
 
   lazy val entrypointTestCmd =
-    s"""'#!/bin/bash\\numask 002;\\necho 'This is coming from entrypoint'\\nuntil /opt/docker/bin/server; do\\n\\techo 'Welder crashed. Respawning..' >&2\\n\\tsleep 1\\ndone'""".stripMargin
+    s"""'#!/bin/bash\\numask 002;\\necho \\'This is coming from entrypoint\\' >&2\\nuntil /opt/docker/bin/server; do\\n\\techo \\'Welder crashed. Respawning..\\' >&2\\n\\tsleep 1\\ndone'""".stripMargin
 
   lazy val commonDockerSettings = List(
     maintainer := "workbench-interactive-analysis@broadinstitute.org",

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -93,12 +93,15 @@ object Settings {
   lazy val entrypoint = "/opt/docker/bin/entrypoint.sh"
 
   lazy val entrypointCmd =
-    s"""echo '#!/bin/bash\\numask 002;
+    s"""#!/bin/bash
+       |numask 002;
        |until /opt/docker/bin/server; do
        |  echo 'Welder crashed. Respawning..' >&2
        |  sleep 1
-       |done' > $entrypoint
-     """.stripMargin
+       |done""".stripMargin
+
+  lazy val entrypointTestCmd =
+    s"""#!/bin/bash\\numask 002; until /opt/docker/bin/server; do\\n\\techo 'Welder crashed. Respawning..' >&2\\n\\tsleep 1\\ndone""".stripMargin
 
   lazy val commonDockerSettings = List(
     maintainer := "workbench-interactive-analysis@broadinstitute.org",
@@ -111,7 +114,7 @@ object Settings {
     dockerCommands ++= List(
       // Change the default umask for welder to support R/W access to the shared volume
       Cmd("USER", "root"),
-      ExecCmd("RUN", "/bin/bash", "-c", entrypointCmd),
+      ExecCmd("RUN", "/bin/bash", "-c", s"echo $entrypointTestCmd > $entrypoint"),
       Cmd("RUN", s"chown -R welder-user:users /opt/docker && chmod u+x,g+x $entrypoint"),
       Cmd("USER", (daemonUser in Docker).value)
     )

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -101,7 +101,7 @@ object Settings {
        |done""".stripMargin
 
   lazy val entrypointTestCmd =
-    s"""'#!/bin/bash\\numask 002;\\necho 'This is coming from entrypoint' >&2\\nuntil /opt/docker/bin/server; do\\n\\techo 'Welder crashed. Respawning..' >&2\\n\\tsleep 1\\ndone'""".stripMargin
+    s"""'#!/bin/bash\\numask 002;\\necho 'This is coming from entrypoint' >> entrypoint.out\\nuntil /opt/docker/bin/server; do\\n\\techo 'Welder crashed. Respawning..' >> entrypoint.out\\n\\tsleep 1\\ndone'""".stripMargin
 
   lazy val commonDockerSettings = List(
     maintainer := "workbench-interactive-analysis@broadinstitute.org",

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -101,7 +101,7 @@ object Settings {
        |done""".stripMargin
 
   lazy val entrypointTestCmd =
-    s"""'#!/bin/bash\\numask 002;\\necho \\'This is coming from entrypoint\\' >&2\\nuntil /opt/docker/bin/server; do\\n\\techo \\'Welder crashed. Respawning..\\' >&2\\n\\tsleep 1\\ndone'""".stripMargin
+    s"""'#!/bin/bash\\numask 002;\\necho 'This is coming from entrypoint' >&2\\nuntil /opt/docker/bin/server; do\\n\\techo 'Welder crashed. Respawning..' >&2\\n\\tsleep 1\\ndone'""".stripMargin
 
   lazy val commonDockerSettings = List(
     maintainer := "workbench-interactive-analysis@broadinstitute.org",

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -92,6 +92,14 @@ object Settings {
 
   lazy val entrypoint = "/opt/docker/bin/entrypoint.sh"
 
+  lazy val entrypointCmd =
+    s"""echo '#!/bin/bash\\numask 002;
+       |until /opt/docker/bin/server; do
+       |  echo 'Welder crashed. Respawning..' >&2
+       |  sleep 1
+       |done' > $entrypoint
+     """.stripMargin
+
   lazy val commonDockerSettings = List(
     maintainer := "workbench-interactive-analysis@broadinstitute.org",
     dockerBaseImage := "oracle/graalvm-ce:1.0.0-rc16",
@@ -103,7 +111,7 @@ object Settings {
     dockerCommands ++= List(
       // Change the default umask for welder to support R/W access to the shared volume
       Cmd("USER", "root"),
-      ExecCmd("RUN", "/bin/bash", "-c", s"echo '#!/bin/bash\\numask 002; /opt/docker/bin/server' > $entrypoint"),
+      ExecCmd("RUN", "/bin/bash", "-c", entrypointCmd),
       Cmd("RUN", s"chown -R welder-user:users /opt/docker && chmod u+x,g+x $entrypoint"),
       Cmd("USER", (daemonUser in Docker).value)
     )


### PR DESCRIPTION
Came out of [this spike](https://broadworkbench.atlassian.net/browse/IA-1452)

I manually tested this by creating a cluster, sshing into it, rewriting the `entrypoint.sh` on Welder, then killing and restarting the java process. I then overwhelmed Welder through a large number of localize requests and watched the logs to see the "respawning" message and saw Welder restarting. 

Now writes the output of `entrypoint.sh` into `/work/entrypoint.out` in the Welder container - this means that it is also in `/work/entrypoint.out` on the VM as well