### PR TITLE
[IA-1785] Try specifying maven repo

### DIFF
--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -84,6 +84,7 @@ object Settings {
     commonBuildSettings ++ List(
       organization := "org.broadinstitute.dsp.workbench",
       scalaVersion := "2.12.10",
+      resolvers -= DefaultMavenRepository,
       resolvers ++= commonResolvers,
       scalacOptions ++= commonCompilerSettings,
       scalafmtOnCompile := true,

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -84,7 +84,6 @@ object Settings {
     commonBuildSettings ++ List(
       organization := "org.broadinstitute.dsp.workbench",
       scalaVersion := "2.12.10",
-      resolvers -= DefaultMavenRepository,
       resolvers ++= commonResolvers,
       scalacOptions ++= commonCompilerSettings,
       scalafmtOnCompile := true,

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -15,7 +15,8 @@ object Settings {
 
   lazy val commonResolvers = List(
     "artifactory-releases" at artifactory + "libs-release",
-    "artifactory-snapshots" at artifactory + "libs-snapshot"
+    "artifactory-snapshots" at artifactory + "libs-snapshot",
+    "Maven Repo" at "https://repo1.maven.org/maven2/"
   )
 
   //coreDefaultSettings + defaultConfigs = the now deprecated defaultSettings


### PR DESCRIPTION
Try to fix build: https://fc-jenkins.dsp-techops.broadinstitute.org/job/welder-publish-image/

Failing with:
```
Getting org.scala-sbt sbt 1.3.8 ...

:: problems summary ::
:::: WARNINGS
		module not found: org.scala-sbt#sbt;1.3.8

	==== local: tried

	  /home/jenkins/.ivy2/local/org.scala-sbt/sbt/1.3.8/ivys/ivy.xml

	  -- artifact org.scala-sbt#sbt;1.3.8!sbt.jar:

	  /home/jenkins/.ivy2/local/org.scala-sbt/sbt/1.3.8/jars/sbt.jar

	==== typesafe-ivy-releases: tried

	  http://repo.typesafe.com/typesafe/ivy-releases/org.scala-sbt/sbt/1.3.8/ivys/ivy.xml

	==== Maven Central: tried

	  http://repo1.maven.org/maven2/org/scala-sbt/sbt/1.3.8/sbt-1.3.8.pom

	  -- artifact org.scala-sbt#sbt;1.3.8!sbt.jar:

	  http://repo1.maven.org/maven2/org/scala-sbt/sbt/1.3.8/sbt-1.3.8.jar

		::::::::::::::::::::::::::::::::::::::::::::::

		::          UNRESOLVED DEPENDENCIES         ::

		::::::::::::::::::::::::::::::::::::::::::::::

		:: org.scala-sbt#sbt;1.3.8: not found

		::::::::::::::::::::::::::::::::::::::::::::::


:::: ERRORS
	SERVER ERROR: HTTPS Required url=http://repo1.maven.org/maven2/org/scala-sbt/sbt/1.3.8/sbt-1.3.8.pom

	SERVER ERROR: HTTPS Required url=http://repo1.maven.org/maven2/org/scala-sbt/sbt/1.3.8/sbt-1.3.8.jar
```

Per this: https://stackoverflow.com/questions/59763435/access-maven-repo-over-https-in-sbt, try specifying the maven resolver via https.