### PR TITLE
[IA-2343] Add AppSec GitHub Trivy Action

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -1,0 +1,42 @@
+name: dsp-appsec-trivy
+on: [pull_request]
+
+jobs:
+  appsec-trivy:
+    # Parse Dockerfile and build, scan image if a "blessed" base image is not used
+    name: DSP AppSec Trivy check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      # fetch SBT package
+      - uses: olafurpg/setup-scala@v10
+
+      # set up SBT cache
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cache
+            ~/.coursier/cache
+            ~/.ivy2/cache
+            ~/.sbt
+          key: sbt-${{ matrix.project }}-${{ hashFiles('**/*.sbt') }}
+          restore-keys: |
+            sbt-${{ matrix.project }}-
+            sbt-
+
+      # build the image
+      - name: Build
+        id: build
+        run: |
+          # build sources and store the log
+          sbt -no-colors server/docker:publishLocal | tee build.log
+
+          # export image name from the log
+          image=$(grep 'Successfully tagged' build.log | head -1 | awk '{print $NF}')
+          echo "::set-output name=image::${image}"
+
+      # scan the image
+      - uses: broadinstitute/dsp-appsec-trivy-action@v1
+        with:
+          image: ${{ steps.build.outputs.image }}

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -20,9 +20,8 @@ jobs:
             ~/.coursier/cache
             ~/.ivy2/cache
             ~/.sbt
-          key: sbt-${{ matrix.project }}-${{ hashFiles('**/*.sbt') }}
+          key: sbt-${{ hashFiles('**/*.sbt') }}
           restore-keys: |
-            sbt-${{ matrix.project }}-
             sbt-
 
       # build the image


### PR DESCRIPTION
This change adds Trivy security scan for the Docker image, as discussed in the Workbench Cross-Team meeting.

The action will run on every PR and give you feedback if the Docker image contains critical OS vulnerabilities.

More info:
https://github.com/broadinstitute/dsp-appsec-trivy-action
https://github.com/broadinstitute/dsp-appsec-blessed-images