### PR TITLE
[IA-2991] Rmd file syncing

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsp/workbench/welder/BackgroundTask.scala
+++ b/core/src/main/scala/org/broadinstitute/dsp/workbench/welder/BackgroundTask.scala
@@ -136,22 +136,25 @@ class BackgroundTask(
       delocalizeResp <- googleStorageAlg
         .delocalize(localObjectPath, gsPath, generation, lastModifiedByMetadataToPush, traceId)
         .recoverWith {
-          case e: com.google.cloud.storage.StorageException if e.getCode == 412 =>
-            val outdatedFileMetadata = lastModifiedByMetadataToPush.++(Map(hashedOwnerEmail.toString() -> "outdated"))
+          case e: GenerationMismatch =>
             if (generation == 0L)
-              logger.info("gen0") >> googleStorageAlg.updateMetadata(gsPath, traceId, outdatedFileMetadata) >> IO.raiseError(e)
+              IO.raiseError(e)
             else {
               // In the case when the file is already been deleted from GCS, we try to delocalize the file with generation being 0L
               // This assumes the business logic we want is always to recreate files that have been deleted from GCS by other users.
               // If the file is indeed out of sync with remote, both delocalize attempts will fail due to generation mismatch
-              logger.info(s"gen: ${generation.toString}") >> googleStorageAlg.delocalize(
+              googleStorageAlg.delocalize(
                 localObjectPath,
                 gsPath,
                 0L,
-                outdatedFileMetadata,
+                lastModifiedByMetadataToPush,
                 traceId
               )
             }
+        }
+        .recoverWith {
+          case e: GenerationMismatch =>
+            googleStorageAlg.updateMetadata(gsPath, traceId, Map(hashedOwnerEmail.toString() -> "outdated")) >> IO.raiseError[DelocalizeResponse](e)
         }
       _ <- metadataCacheAlg.updateLocalFileStateCache(localObjectPath, RemoteState.Found(None, delocalizeResp.crc32c), delocalizeResp.generation)
     } yield ()

--- a/core/src/main/scala/org/broadinstitute/dsp/workbench/welder/BackgroundTask.scala
+++ b/core/src/main/scala/org/broadinstitute/dsp/workbench/welder/BackgroundTask.scala
@@ -107,7 +107,7 @@ class BackgroundTask(
     for {
       traceId <- ev.ask[TraceId]
       localAbsolutePath = config.workingDirectory.resolve(localObjectPath.asPath) //TODO: make sure this is correct
-      _ <- logger.info(s"local absolute path ${localAbsolutePath}")
+      _ <- logger.info(s"! local absolute path ${localAbsolutePath}")
       previousMeta <- metadataCacheAlg.getCache(localObjectPath)
       calculatedCrc32c <- Crc32c.calculateCrc32ForFile(localAbsolutePath, blocker)
 
@@ -146,7 +146,7 @@ class BackgroundTask(
         }
         .recoverWith {
           case e: com.google.cloud.storage.StorageException if e.getCode == 412 =>
-            googleStorageAlg.updateMetadata(gsPath, traceId, Map("outdated" -> config.ownerEmail.value)) >> IO.raiseError[DelocalizeResponse](e)
+            googleStorageAlg.updateMetadata(gsPath, traceId, Map(hashedOwnerEmail.toString() -> "outdated")) >> IO.raiseError[DelocalizeResponse](e)
         }
       _ <- metadataCacheAlg.updateLocalFileStateCache(localObjectPath, RemoteState.Found(None, delocalizeResp.crc32c), delocalizeResp.generation)
     } yield ()

--- a/core/src/main/scala/org/broadinstitute/dsp/workbench/welder/BackgroundTask.scala
+++ b/core/src/main/scala/org/broadinstitute/dsp/workbench/welder/BackgroundTask.scala
@@ -92,7 +92,10 @@ class BackgroundTask(
           if (storageLink.pattern.toString.contains(".Rmd")) {
             findFilesWithPattern(config.workingDirectory.resolve(storageLink.localBaseDirectory.path.asPath), storageLink.pattern).traverse_ { file =>
               val gsPath = getGsPath(storageLink, new File(file.getName))
-              safeDelocalize(gsPath, RelativePath(java.nio.file.Paths.get(file.getName)))
+              logger.info(s"!! gsPath: ${gsPath.toString}, file: ${file.getName}") >> safeDelocalize(
+                gsPath,
+                RelativePath(java.nio.file.Paths.get(file.getName))
+              )
             }
           } else IO.unit
         }
@@ -106,8 +109,8 @@ class BackgroundTask(
   def safeDelocalize(gsPath: GsPath, localObjectPath: RelativePath)(implicit ev: Ask[IO, TraceId]): IO[Unit] =
     for {
       traceId <- ev.ask[TraceId]
-      localAbsolutePath = config.workingDirectory.resolve(localObjectPath.asPath) //TODO: make sure this is correct
-      _ <- logger.info(s"! local absolute path ${localAbsolutePath}")
+      localAbsolutePath = config.workingDirectory.resolve(localObjectPath.asPath)
+      _ = logger.info(s"!! localAbsolutePath: ${localAbsolutePath.toString}")
       previousMeta <- metadataCacheAlg.getCache(localObjectPath)
       calculatedCrc32c <- Crc32c.calculateCrc32ForFile(localAbsolutePath, blocker)
 

--- a/core/src/main/scala/org/broadinstitute/dsp/workbench/welder/GoogleStorageInterp.scala
+++ b/core/src/main/scala/org/broadinstitute/dsp/workbench/welder/GoogleStorageInterp.scala
@@ -91,6 +91,7 @@ class GoogleStorageInterp(config: GoogleStorageAlgConfig, blocker: Blocker, goog
     val localAbsolutePath = config.workingDirectory.resolve(localObjectPath.asPath)
 
     for {
+      _ <- logger.info(s"Trace Id: ${traceId.asString} | Delocalizing file: ${localAbsolutePath.toString}")
       _ <- (io.file.readAll[IO](localAbsolutePath, blocker, 4096) through googleStorageService.streamUploadBlob(
         gsPath.bucketName,
         gsPath.blobName,

--- a/core/src/main/scala/org/broadinstitute/dsp/workbench/welder/GoogleStorageInterp.scala
+++ b/core/src/main/scala/org/broadinstitute/dsp/workbench/welder/GoogleStorageInterp.scala
@@ -28,7 +28,7 @@ class GoogleStorageInterp(config: GoogleStorageAlgConfig, blocker: Blocker, goog
   private val chunkSize = 1024 * 1024 * 2 // com.google.cloud.storage.BlobReadChannel.DEFAULT_CHUNK_SIZE
 
   def updateMetadata(gsPath: GsPath, traceId: TraceId, metadata: Map[String, String]): IO[UpdateMetadataResponse] =
-    logger.info(s"updateMetadata: ${metadata}") >> googleStorageService
+    googleStorageService
       .setObjectMetadata(gsPath.bucketName, gsPath.blobName, metadata, Option(traceId))
       .compile
       .drain

--- a/core/src/main/scala/org/broadinstitute/dsp/workbench/welder/GoogleStorageInterp.scala
+++ b/core/src/main/scala/org/broadinstitute/dsp/workbench/welder/GoogleStorageInterp.scala
@@ -28,7 +28,7 @@ class GoogleStorageInterp(config: GoogleStorageAlgConfig, blocker: Blocker, goog
   private val chunkSize = 1024 * 1024 * 2 // com.google.cloud.storage.BlobReadChannel.DEFAULT_CHUNK_SIZE
 
   def updateMetadata(gsPath: GsPath, traceId: TraceId, metadata: Map[String, String]): IO[UpdateMetadataResponse] =
-    googleStorageService
+    logger.info(s"updateMetadata: ${metadata}") >> googleStorageService
       .setObjectMetadata(gsPath.bucketName, gsPath.blobName, metadata, Option(traceId))
       .compile
       .drain

--- a/core/src/test/scala/org/broadinstitute/dsp/workbench/welder/BackgroundTaskSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsp/workbench/welder/BackgroundTaskSpec.scala
@@ -2,12 +2,10 @@ package org.broadinstitute.dsp.workbench.welder
 
 import cats.effect.{Blocker, IO}
 import cats.effect.concurrent.Ref
-// import fs2.Stream
-import org.broadinstitute.dsde.workbench.google2.{Crc32, GetMetadataResponse, GoogleStorageService}
+import org.broadinstitute.dsde.workbench.google2.GoogleStorageService
 import org.broadinstitute.dsde.workbench.google2.mock.FakeGoogleStorageInterpreter
 import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
 import org.broadinstitute.dsde.workbench.model.google.GcsBucketName
-import org.broadinstitute.dsp.workbench.welder.Generators.{genGsPath, genRmdFile, genRmdStorageLink}
 import org.broadinstitute.dsp.workbench.welder.LocalDirectory.LocalBaseDirectory
 import org.scalatest.flatspec.AnyFlatSpec
 
@@ -38,53 +36,6 @@ class BackgroundTaskSpec extends AnyFlatSpec with WelderTestSuite {
     val file = new File("test.Rmd")
     val res = initBackgroundTask(Map(storageLink.localBaseDirectory.path -> storageLink), Map.empty, None, blocker).getGsPath(storageLink, file)
     res.toString shouldBe s"gs://testBucket/notebooks/test.Rmd"
-  }
-
-  // TODO: update unit tests to reflect changes in code
-
-  "shouldDelocalize" should "return false if files have not changed" in {
-    val metadataResp = GetMetadataResponse.Metadata(Crc32("aZKdIw=="), Map.empty, 0L) //This crc32c is from the file created in this test
-    val storageService = FakeGoogleStorageService(metadataResp)
-    val localAbsolutePath = genRmdFile.sample.get
-    val bodyBytes = "this is great!".getBytes("UTF-8")
-    val storageLink = genRmdStorageLink.sample.get
-    val gsPath = genGsPath.sample.get
-    val backgroundTask = initBackgroundTask(Map(storageLink.localBaseDirectory.path -> storageLink), Map.empty, Some(storageService), blocker)
-//    val res = for {
-//      _ <- Stream.emits(bodyBytes).covary[IO].through(fs2.io.file.writeAll[IO](localAbsolutePath, blocker)).compile.drain
-//      r <- backgroundTask.shouldDelocalize(gsPath, localAbsolutePath)
-//    } yield (r shouldBe (false))
-//    res.unsafeRunSync()
-  }
-
-  "shouldDelocalize" should "return true if files have changed" in {
-    val metadataResp = GetMetadataResponse.Metadata(Crc32("trIjMQ=="), Map.empty, 0L) //This crc32c is to not match the file's crc32c created in this test
-    val storageService = FakeGoogleStorageService(metadataResp)
-    val localAbsolutePath = genRmdFile.sample.get
-    val bodyBytes = "this is great!".getBytes("UTF-8")
-    val storageLink = genRmdStorageLink.sample.get
-    val gsPath = genGsPath.sample.get
-//    val backgroundTask = initBackgroundTask(Map(storageLink.localBaseDirectory.path -> storageLink), Map.empty, Some(storageService), blocker)
-//    val res = for {
-//      _ <- Stream.emits(bodyBytes).covary[IO].through(fs2.io.file.writeAll[IO](localAbsolutePath, blocker)).compile.drain
-//      r <- backgroundTask.shouldDelocalize(gsPath, localAbsolutePath)
-//    } yield (r shouldBe (true))
-//    res.unsafeRunSync()
-  }
-
-  "shouldDelocalize" should "return true if the file does not exist in Google" in {
-    val metadataResp = GetMetadataResponse.NotFound
-    val storageService = FakeGoogleStorageService(metadataResp)
-    val localAbsolutePath = genRmdFile.sample.get
-    val bodyBytes = "this is great!".getBytes("UTF-8")
-    val storageLink = genRmdStorageLink.sample.get
-    val gsPath = genGsPath.sample.get
-    val backgroundTask = initBackgroundTask(Map(storageLink.localBaseDirectory.path -> storageLink), Map.empty, Some(storageService), blocker)
-//    val res = for {
-//      _ <- Stream.emits(bodyBytes).covary[IO].through(fs2.io.file.writeAll[IO](localAbsolutePath, blocker)).compile.drain
-//      r <- backgroundTask.shouldDelocalize(gsPath, localAbsolutePath)
-//    } yield (r shouldBe (true))
-//    res.unsafeRunSync()
   }
 
   private def initBackgroundTask(

--- a/server/src/main/scala/org/broadinstitute/dsp/workbench/welder/server/Main.scala
+++ b/server/src/main/scala/org/broadinstitute/dsp/workbench/welder/server/Main.scala
@@ -93,10 +93,11 @@ object Main extends IOApp {
         appConfig.flushCacheInterval,
         appConfig.syncCloudStorageDirectoryInterval,
         appConfig.delocalizeDirectoryInterval,
-        appConfig.isRstudioRuntime
+        appConfig.isRstudioRuntime,
+        appConfig.objectService.ownerEmail
       )
       val backGroundTask =
-        new BackgroundTask(backGroundTaskConfig, metadataCache, storageLinksCache, googleStorageAlg, metadataCacheAlg, googleStorageService, blocker)
+        new BackgroundTask(backGroundTaskConfig, metadataCache, storageLinksCache, googleStorageAlg, metadataCacheAlg, blocker)
       val flushCache = backGroundTask.flushBothCache(
         appConfig.storageLinksJsonBlobName,
         appConfig.gcsMetadataJsonBlobName,


### PR DESCRIPTION
delocalization looks good locally - creating a file on my local machine, hitting the `POST storageLinks` endpoint and validating that the file gets delocalized to bucket looks good.

Tested end to end in a Fiab with this Leo [PR](https://github.com/DataBiosphere/leonardo/pull/2530) and this UI [PR](https://github.com/DataBiosphere/terra-ui/pull/2810) and everything works as expected. Welder throws a generation mismatch error if user1 creates file1, then file1 gets localized to user2's VM, then user2 makes some changes. then user1 comes back and does not get user2's changes and makes their own changes and tries to save -> when user1 saves, they get a generation mismatch error since they have an outdated version of file1. verified that file1's metadata gets updated in GCS when this happens to reflect that they have an outdated version of the file. 