### PR TITLE
[IA-3445] Added .R file support

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsp/workbench/welder/BackgroundTask.scala
+++ b/core/src/main/scala/org/broadinstitute/dsp/workbench/welder/BackgroundTask.scala
@@ -92,7 +92,7 @@ class BackgroundTask(
         storageLinks <- storageLinksCache.get
         implicit0(tid: Ask[IO, TraceId]) <- IO(TraceId(UUID.randomUUID().toString)).map(tid => Ask.const[IO, TraceId](tid))
         _ <- storageLinks.values.toList.traverse { storageLink =>
-          if (storageLink.pattern.toString.contains(".Rmd")) {
+          if (storageLink.pattern.toString == ".*\\.Rmd" || storageLink.pattern.toString == ".*\\.R") {
             findFilesWithPattern(config.workingDirectory.resolve(storageLink.localBaseDirectory.path.asPath), storageLink.pattern).traverse_ { file =>
               val gsPath = getGsPath(storageLink, new File(file.getName))
               checkSyncStatus(


### PR DESCRIPTION
Added .R file support so that .R files will be delocalized.

Testing steps:
- Created a local Welder server
- Created .R files on my computer
- Made a POST request to the server so that it would delocalize .R files (ie. `curl -vX POST --header 'Content-Type: application/json' --header 'Accept: application/json' localhost:8080/storageLinks -d '{"localBaseDirectory": "", "localSafeModeBaseDirectory": "", "cloudStorageDirectory": "gs://fc-d01f8619-06cd-443d-86f2-8e80b0fb33f3/notebooks", "pattern": ".*\\.R" }'`)
- Verified that the files delocalized to the workspace bucket for the given workspace
- Verified that edits to a file also delocalized as expected
- Repeated these steps for .Rmd files as well to make sure support was not deprecated by my changes