### PR TITLE
PROD-695 Fix bug where Rmd and .R files aren't syncing properly

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsp/workbench/welder/BackgroundTask.scala
+++ b/core/src/main/scala/org/broadinstitute/dsp/workbench/welder/BackgroundTask.scala
@@ -93,7 +93,7 @@ class BackgroundTask(
         storageLinks <- storageLinksCache.get
         implicit0(tid: Ask[IO, TraceId]) <- IO(TraceId(UUID.randomUUID().toString)).map(tid => Ask.const[IO, TraceId](tid))
         _ <- storageLinks.values.toList.traverse { storageLink =>
-          findFilesWithPattern(config.workingDirectory.resolve(storageLink.localBaseDirectory.path.asPath), storageLink.pattern).traverse_ { file =>
+          findFilesWithROrRmdPattern(config.workingDirectory.resolve(storageLink.localBaseDirectory.path.asPath)).traverse_ { file =>
             val gsPath = getGsPath(storageLink, new File(file.getName))
             checkSyncStatus(
               gsPath,

--- a/core/src/main/scala/org/broadinstitute/dsp/workbench/welder/BackgroundTask.scala
+++ b/core/src/main/scala/org/broadinstitute/dsp/workbench/welder/BackgroundTask.scala
@@ -15,7 +15,6 @@ import java.io.File
 import java.nio.file.Path
 import java.util.UUID
 import scala.concurrent.duration.FiniteDuration
-import scala.util.matching.Regex
 
 class BackgroundTask(
     config: BackgroundTaskConfig,
@@ -94,15 +93,13 @@ class BackgroundTask(
         storageLinks <- storageLinksCache.get
         implicit0(tid: Ask[IO, TraceId]) <- IO(TraceId(UUID.randomUUID().toString)).map(tid => Ask.const[IO, TraceId](tid))
         _ <- storageLinks.values.toList.traverse { storageLink =>
-          if (BackgroundTask.shouldSync(storageLink.pattern.toString())) {
-            findFilesWithPattern(config.workingDirectory.resolve(storageLink.localBaseDirectory.path.asPath), storageLink.pattern).traverse_ { file =>
-              val gsPath = getGsPath(storageLink, new File(file.getName))
-              checkSyncStatus(
-                gsPath,
-                RelativePath(java.nio.file.Paths.get(file.getName))
-              )
-            }
-          } else IO.unit
+          findFilesWithPattern(config.workingDirectory.resolve(storageLink.localBaseDirectory.path.asPath), storageLink.pattern).traverse_ { file =>
+            val gsPath = getGsPath(storageLink, new File(file.getName))
+            checkSyncStatus(
+              gsPath,
+              RelativePath(java.nio.file.Paths.get(file.getName))
+            )
+          }
         }
       } yield ()).handleErrorWith(r => logger.info(r)(s"Unexpected error encountered ${r}"))
       (Stream.sleep[IO](config.delocalizeDirectoryInterval) ++ Stream.eval(res)).repeat
@@ -203,11 +200,6 @@ class BackgroundTask(
     )
     GsPath(storageLink.cloudStorageDirectory.bucketName, fullBlobPath)
   }
-}
-
-object BackgroundTask {
-  val filesShouldSyncRegex: Regex = ".*(.R)$|(.Rmd)$".r
-  def shouldSync(storageLinkPattern: String): Boolean = filesShouldSyncRegex.findFirstIn(storageLinkPattern).isDefined
 }
 
 final case class BackgroundTaskConfig(

--- a/core/src/main/scala/org/broadinstitute/dsp/workbench/welder/package.scala
+++ b/core/src/main/scala/org/broadinstitute/dsp/workbench/welder/package.scala
@@ -27,6 +27,7 @@ package object welder {
   val TRACE_ID_LOGGING_KEY = "traceId"
 
   val gsDirectoryReg = "gs:\\/\\/.*".r
+  val filesShouldSyncInBackgroundRegex: Regex = ".*(.R)$|(.Rmd)$".r
 
   def validateGsPrefix(str: String): Either[String, Unit] = gsDirectoryReg.findPrefixOf(str).void.toRight("gs directory has to be prefixed with gs://")
 
@@ -185,8 +186,8 @@ package object welder {
   def findFilesWithSuffix(parent: Path, suffix: String): List[File] =
     parent.toFile.listFiles().filter(f => f.isFile && f.getName.endsWith(suffix)).toList
 
-  def findFilesWithPattern(parent: Path, pattern: Regex): List[File] =
-    parent.toFile.listFiles().filter(f => f.isFile && pattern.findFirstIn(f.getName).isDefined).toList
+  def findFilesWithROrRmdPattern(parent: Path): List[File] =
+    parent.toFile.listFiles().filter(f => f.isFile && filesShouldSyncInBackgroundRegex.findFirstIn(f.getName).isDefined).toList
 
   private[welder] val writeFileOptions = Flags.Write
 

--- a/core/src/test/scala/org/broadinstitute/dsp/workbench/welder/BackgroundTaskSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsp/workbench/welder/BackgroundTaskSpec.scala
@@ -37,14 +37,6 @@ class BackgroundTaskSpec extends AnyFlatSpec with WelderTestSuite {
     res.toString shouldBe s"gs://testBucket/notebooks/test.Rmd"
   }
 
-  "shouldSync" should "return true if passed a supported pattern" in {
-    BackgroundTask.shouldSync("test.R") shouldBe true
-    BackgroundTask.shouldSync("test.Rdd") shouldBe false
-    BackgroundTask.shouldSync("test.Rmd") shouldBe true
-    BackgroundTask.shouldSync("test.py") shouldBe false
-    BackgroundTask.shouldSync("test.Rmddd") shouldBe false
-  }
-
   private def initBackgroundTask(
       storageLinks: Map[RelativePath, StorageLink],
       metadata: Map[RelativePath, AdaptedGcsMetadataCache],

--- a/core/src/test/scala/org/broadinstitute/dsp/workbench/welder/PackageSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsp/workbench/welder/PackageSpec.scala
@@ -79,16 +79,13 @@ class PackageSpec extends AnyFlatSpec with ScalaCheckPropertyChecks with WelderT
     }
   }
 
-  "findFilesWithPattern" should "only find files with certain pattern" in {
+  "findFilesWithROrRmdPattern" should "only find files with certain pattern" in {
     val parentPath = Paths.get("/tmp")
     new java.io.File(parentPath.resolve("test.R").toUri).createNewFile()
     new java.io.File(parentPath.resolve("test.R1").toUri).createNewFile()
     new java.io.File(parentPath.resolve("test.Rmd").toUri).createNewFile()
     new java.io.File(parentPath.resolve("test.ipynb").toUri).createNewFile()
-    val resR = findFilesWithPattern(parentPath, ".*(.R)$|(.Rmd)$".r)
+    val resR = findFilesWithROrRmdPattern(parentPath)
     resR shouldBe List(new File("/tmp/test.R"), new File("/tmp/test.Rmd"))
-
-    val resIpynb = findFilesWithPattern(parentPath, ".*.ipynb$".r)
-    resIpynb shouldBe List(new File("/tmp/test.ipynb"))
   }
 }

--- a/core/src/test/scala/org/broadinstitute/dsp/workbench/welder/PackageSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsp/workbench/welder/PackageSpec.scala
@@ -12,6 +12,8 @@ import org.broadinstitute.dsp.workbench.welder.SourceUri.GsPath
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 
+import java.io.File
+
 class PackageSpec extends AnyFlatSpec with ScalaCheckPropertyChecks with WelderTestSuite {
   "parseGsPath" should "be able to parse gs path correctly" in {
     forAll { (bucketName: GcsBucketName) =>
@@ -75,5 +77,18 @@ class PackageSpec extends AnyFlatSpec with ScalaCheckPropertyChecks with WelderT
           .unsafeRunSync()
       res.get.unsafeRunSync() shouldBe Map.empty
     }
+  }
+
+  "findFilesWithPattern" should "only find files with certain pattern" in {
+    val parentPath = Paths.get("/tmp")
+    new java.io.File(parentPath.resolve("test.R").toUri).createNewFile()
+    new java.io.File(parentPath.resolve("test.R1").toUri).createNewFile()
+    new java.io.File(parentPath.resolve("test.Rmd").toUri).createNewFile()
+    new java.io.File(parentPath.resolve("test.ipynb").toUri).createNewFile()
+    val resR = findFilesWithPattern(parentPath, ".*(.R)$|(.Rmd)$".r)
+    resR shouldBe List(new File("/tmp/test.R"), new File("/tmp/test.Rmd"))
+
+    val resIpynb = findFilesWithPattern(parentPath, ".*.ipynb$".r)
+    resIpynb shouldBe List(new File("/tmp/test.ipynb"))
   }
 }


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/PROD-695

```
{"@timestamp":"2022-07-15T21:42:57.033Z","@version":"1","message":"Delocalizing file /work/qi-test.R","logger_name":"org.broadinstitute.dsp.workbench.welder.server.Main","thread_name":"io-compute-4","severity":"INFO","level_value":20000,"traceId":"242b5c44-7aca-4771-ab6c-992bfe62fc2f"}
{"@timestamp":"2022-07-15T21:47:58.419Z","@version":"1","message":"Delocalizing file /work/qitest.Rmd","logger_name":"org.broadinstitute.dsp.workbench.welder.server.Main","thread_name":"io-compute-3","severity":"INFO","level_value":20000,"traceId":"0dab79bd-cc0c-4ce2-8546-0da0444d4344"}
```