### PR TITLE
PROD-695 better fix

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsp/workbench/welder/BackgroundTask.scala
+++ b/core/src/main/scala/org/broadinstitute/dsp/workbench/welder/BackgroundTask.scala
@@ -93,7 +93,7 @@ class BackgroundTask(
         storageLinks <- storageLinksCache.get
         implicit0(tid: Ask[IO, TraceId]) <- IO(TraceId(UUID.randomUUID().toString)).map(tid => Ask.const[IO, TraceId](tid))
         _ <- storageLinks.values.toList.traverse { storageLink =>
-          findFilesWithROrRmdPattern(config.workingDirectory.resolve(storageLink.localBaseDirectory.path.asPath)).traverse_ { file =>
+          findFilesWithPattern(config.workingDirectory.resolve(storageLink.localBaseDirectory.path.asPath), storageLink.pattern).traverse_ { file =>
             val gsPath = getGsPath(storageLink, new File(file.getName))
             checkSyncStatus(
               gsPath,

--- a/core/src/main/scala/org/broadinstitute/dsp/workbench/welder/package.scala
+++ b/core/src/main/scala/org/broadinstitute/dsp/workbench/welder/package.scala
@@ -27,7 +27,6 @@ package object welder {
   val TRACE_ID_LOGGING_KEY = "traceId"
 
   val gsDirectoryReg = "gs:\\/\\/.*".r
-  val filesShouldSyncInBackgroundRegex: Regex = ".*(.R)$|(.Rmd)$".r
 
   def validateGsPrefix(str: String): Either[String, Unit] = gsDirectoryReg.findPrefixOf(str).void.toRight("gs directory has to be prefixed with gs://")
 
@@ -186,8 +185,8 @@ package object welder {
   def findFilesWithSuffix(parent: Path, suffix: String): List[File] =
     parent.toFile.listFiles().filter(f => f.isFile && f.getName.endsWith(suffix)).toList
 
-  def findFilesWithROrRmdPattern(parent: Path): List[File] =
-    parent.toFile.listFiles().filter(f => f.isFile && filesShouldSyncInBackgroundRegex.findFirstIn(f.getName).isDefined).toList
+  def findFilesWithPattern(parent: Path, pattern: Regex): List[File] =
+    parent.toFile.listFiles().filter(f => f.isFile && pattern.findFirstIn(f.getName).isDefined).toList
 
   private[welder] val writeFileOptions = Flags.Write
 

--- a/core/src/test/scala/org/broadinstitute/dsp/workbench/welder/PackageSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsp/workbench/welder/PackageSpec.scala
@@ -79,13 +79,16 @@ class PackageSpec extends AnyFlatSpec with ScalaCheckPropertyChecks with WelderT
     }
   }
 
-  "findFilesWithROrRmdPattern" should "only find files with certain pattern" in {
+  "findFilesWithPattern" should "only find files with certain pattern" in {
     val parentPath = Paths.get("/tmp")
     new java.io.File(parentPath.resolve("test.R").toUri).createNewFile()
     new java.io.File(parentPath.resolve("test.R1").toUri).createNewFile()
     new java.io.File(parentPath.resolve("test.Rmd").toUri).createNewFile()
     new java.io.File(parentPath.resolve("test.ipynb").toUri).createNewFile()
-    val resR = findFilesWithROrRmdPattern(parentPath)
+    val resR = findFilesWithPattern(parentPath, ".*(.R)$|(.Rmd)$".r)
     resR shouldBe List(new File("/tmp/test.R"), new File("/tmp/test.Rmd"))
+
+    val resIpynb = findFilesWithPattern(parentPath, ".*.ipynb$".r)
+    resIpynb shouldBe List(new File("/tmp/test.ipynb"))
   }
 }


### PR DESCRIPTION
This reverts commit 99d2ea7c7919b8d9adaf5ec481d01b7dd283a57b.

So in previous PR, we were hard coding the pattern, but I think shouldn't need to. I was previously confused thinking we shouldn't sync ipynb files, hence we need to specifically filter on .R or .Rmd files, but we're already guarding that with the config check to see if this is an RStudio runtime.