### PR TITLE
IA-3705 Bump dependencies

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -6,7 +6,7 @@ steps:
       - 'IS_RSTUDIO_RUNTIME=false'
     args:
       - |
-        test; server/docker:publishLocal
+        sbt test; server/docker:publishLocal
   - name: 'gcr.io/cloud-builders/docker'
     args: [ 'image', 'tag', 'us.gcr.io/broad-dsp-gcr-public/welder-server:latest', 'us.gcr.io/broad-dsp-gcr-public/welder-server:$SHORT_SHA']
 images: [

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -6,7 +6,7 @@ steps:
       - 'IS_RSTUDIO_RUNTIME=false'
     args:
       - |
-        sbt "test; server/docker:publishLocal"
+        test; server/docker:publishLocal
   - name: 'gcr.io/cloud-builders/docker'
     args: [ 'image', 'tag', 'us.gcr.io/broad-dsp-gcr-public/welder-server:latest', 'us.gcr.io/broad-dsp-gcr-public/welder-server:$SHORT_SHA']
 images: [

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -7,8 +7,6 @@ steps:
     args:
       - |
         test; server/docker:publishLocal
-#  - name: 'gcr.io/cloud-builders/docker'
-#    args: [ 'image', 'tag', 'us.gcr.io/broad-dsp-gcr-public/welder-server:$SHORT_SHA']
 images: [
     'us.gcr.io/broad-dsp-gcr-public/welder-server:$SHORT_SHA'
 ]

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -6,7 +6,7 @@ steps:
       - 'IS_RSTUDIO_RUNTIME=false'
     args:
       - |
-        sbt test; server/docker:publishLocal
+        sbt "test; server/docker:publishLocal"
   - name: 'gcr.io/cloud-builders/docker'
     args: [ 'image', 'tag', 'us.gcr.io/broad-dsp-gcr-public/welder-server:latest', 'us.gcr.io/broad-dsp-gcr-public/welder-server:$SHORT_SHA']
 images: [

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -7,9 +7,8 @@ steps:
     args:
       - |
         test; server/docker:publishLocal
-  - name: 'gcr.io/cloud-builders/docker'
-    args: [ 'image', 'tag', 'us.gcr.io/broad-dsp-gcr-public/welder-server:latest', 'us.gcr.io/broad-dsp-gcr-public/welder-server:$SHORT_SHA']
+#  - name: 'gcr.io/cloud-builders/docker'
+#    args: [ 'image', 'tag', 'us.gcr.io/broad-dsp-gcr-public/welder-server:$SHORT_SHA']
 images: [
-    'us.gcr.io/broad-dsp-gcr-public/welder-server:$SHORT_SHA',
-    'us.gcr.io/broad-dsp-gcr-public/welder-server:latest'
+    'us.gcr.io/broad-dsp-gcr-public/welder-server:$SHORT_SHA'
 ]

--- a/core/src/main/scala/org/broadinstitute/dsp/workbench/welder/package.scala
+++ b/core/src/main/scala/org/broadinstitute/dsp/workbench/welder/package.scala
@@ -43,7 +43,7 @@ package object welder {
       length = s"${bucketName.name}/".length
       objectName <- Either
         .catchNonFatal(parsed.drop(length))
-        .leftMap(_ => s"failed to parse object name")
+        .leftMap(_ => s"failed to parse object name.")
         .ensure("objectName can't be empty")(s => s.nonEmpty)
     } yield CloudBlobPath(bucketName, CloudStorageBlob(objectName))
   }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,11 +3,11 @@ import sbt._
 object Dependencies {
   val circeVersion = "0.14.2"
   val http4sVersion = "1.0.0-M35"
-  val grpcCoreVersion = "1.49.0"
-  val scalaTestVersion = "3.2.13"
+  val grpcCoreVersion = "1.49.2"
+  val scalaTestVersion = "3.2.14"
 
-  val workbenchLibsHash = "0096bac"
-  val workbenchGoogle2V = s"0.24-$workbenchLibsHash"
+  val workbenchLibsHash = "e6ad8a1"
+  val workbenchGoogle2V = s"0.25-$workbenchLibsHash"
   val workbenchAzureV = s"0.1-$workbenchLibsHash"
 
   val common = List(
@@ -27,8 +27,8 @@ object Dependencies {
     "org.broadinstitute.dsde.workbench" %% "workbench-azure" % workbenchAzureV,
     "org.broadinstitute.dsde.workbench" %% "workbench-azure" % workbenchAzureV % "test" classifier "tests", //for generators/mocks
     "ca.mrvisser" %% "sealerate" % "0.0.6",
-    "com.google.cloud" % "google-cloud-nio" % "0.124.14" % "test",
-    "ch.qos.logback" % "logback-classic" % "1.4.0",
+    "com.google.cloud" % "google-cloud-nio" % "0.124.16" % "test",
+    "ch.qos.logback" % "logback-classic" % "1.4.3",
     "net.logstash.logback" % "logstash-logback-encoder" % "7.2" // for structured logging in logback
   )
 

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -62,7 +62,7 @@ object Settings {
   lazy val commonSettings =
     commonBuildSettings ++ List(
       organization := "org.broadinstitute.dsp.workbench",
-      scalaVersion := "2.13.8",
+      scalaVersion := "2.13.9",
       resolvers ++= commonResolvers,
       scalacOptions ++= commonCompilerSettings,
       scalafmtOnCompile := true,

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.7.1
+sbt.version=1.7.2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.9.2")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.6")
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.0.2")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.0.4")
 addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.9.11")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.11.0")
 addSbtPlugin("com.github.sbt" % "sbt-git" % "2.0.0")


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-3705

* Bump a few dependencies
* Fix cloud-build for sbt projects. This real fix is in `dsp-cloud-build` project itself, basically we needed to upload newer scala-sbt builder that's running on java17. Sample [successful run](https://console.cloud.google.com/cloud-build/builds;region=global/0f7eb6e6-c12d-4f4e-969a-9df19eb6db46?authuser=0&project=dsp-cloud-build)

Here's what I did for uploading new builder

* Check out https://github.com/GoogleCloudPlatform/cloud-builders-community/tree/master/scala-sbt
* Update `Dockerfile` to 
```
ARG BASE_IMAGE=sbtscala/scala-sbt:eclipse-temurin-11.0.16_1.7.2_3.2.0
FROM ${BASE_IMAGE}

RUN apt-get update -qqy \
  && java -version \
  && apt-get install -qqy apt-transport-https ca-certificates curl software-properties-common sudo gcc libffi-dev make bc \
  && curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add - \
  && apt-key fingerprint 0EBFCD88 \
  && add-apt-repository \
        "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
        $(lsb_release -cs) \
        stable" \
  && apt-get -y update \
  && apt-get -y install docker-ce

ENTRYPOINT ["/usr/local/bin/sbt"]

```

* Update cloudbuild.yaml to 
```
steps:
- name: 'gcr.io/cloud-builders/docker'
  args:
  - 'build'
  - '--tag=gcr.io/$PROJECT_ID/scala-sbt:1.7.2-jdk-17'
  - '.'
  waitFor: ['-']

# Tag the default 'latest' version
- name: 'gcr.io/cloud-builders/docker'
  args:
  - 'tag'
  - 'gcr.io/$PROJECT_ID/scala-sbt:1.7.2-jdk-17'
  - 'gcr.io/$PROJECT_ID/scala-sbt'

images:
- 'gcr.io/$PROJECT_ID/scala-sbt'
- 'gcr.io/$PROJECT_ID/scala-sbt:1.7.2-jdk-17'
tags: ['cloud-builders-community']
```

* Run `gcloud builds submit . --config=cloudbuild.yaml --project dsp-cloud-build` in the `scala-sbt` directory