### PR TITLE
IA-3852 increase sas token expiration time

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsp/workbench/welder/MiscHttpClientAlg.scala
+++ b/core/src/main/scala/org/broadinstitute/dsp/workbench/welder/MiscHttpClientAlg.scala
@@ -3,17 +3,19 @@ package org.broadinstitute.dsp.workbench.welder
 import cats.effect.IO
 import io.circe.Decoder
 import org.http4s.Uri
-import java.util.UUID
 
+import java.util.UUID
 import cats.implicits._
 import org.broadinstitute.dsde.workbench.azure.SasToken
+
+import scala.concurrent.duration.FiniteDuration
 
 trait MiscHttpClientAlg {
   def getPetAccessToken(): IO[PetAccessTokenResp]
   def getSasUrl(petAccessToken: PetAccessToken, storageContainerResourceId: UUID): IO[SasTokenResp]
 }
 
-final case class MiscHttpClientConfig(wsmUrl: Uri, workspaceId: UUID)
+final case class MiscHttpClientConfig(wsmUrl: Uri, workspaceId: UUID, sasTokenExpiresIn: FiniteDuration)
 final case class PetAccessToken(value: String) extends AnyVal
 final case class PetAccessTokenResp(accessToken: PetAccessToken)
 final case class SasTokenResp(uri: Uri, token: SasToken)

--- a/core/src/main/scala/org/broadinstitute/dsp/workbench/welder/MiscHttpClientInterp.scala
+++ b/core/src/main/scala/org/broadinstitute/dsp/workbench/welder/MiscHttpClientInterp.scala
@@ -41,6 +41,7 @@ class MiscHttpClientInterp(httpClient: Client[IO], config: MiscHttpClientConfig)
   override def getSasUrl(petAccessToken: PetAccessToken, storageContainerResourceId: UUID): IO[SasTokenResp] = {
     val uri =
       (config.wsmUrl / "api" / "workspaces" / "v1" / config.workspaceId.toString / "resources" / "controlled" / "azure" / "storageContainer" / storageContainerResourceId.toString / "getSasToken")
+        .withQueryParam("sasExpirationDuration", config.sasTokenExpiresIn.toSeconds)
     httpClient.expect[SasTokenResp](
       Request[IO](
         method = Method.POST,

--- a/server/src/main/resources/reference.conf
+++ b/server/src/main/resources/reference.conf
@@ -18,6 +18,7 @@ is-rstudio-runtime = ${IS_RSTUDIO_RUNTIME}
 misc-http-client-config = {
   wsm-url = ${WSM_URL}
   workspace-id = ${WORKSPACE_ID}
+  sas-token-expires-in = 8 hours
 }
 workspace-storage-container-resource-id = ${STORAGE_CONTAINER_RESOURCE_ID}
 staging-storage-container-resource-id = ${STAGING_STORAGE_CONTAINER_RESOURCE_ID}

--- a/server/src/main/scala/org/broadinstitute/dsp/workbench/welder/server/BackgroundTask.scala
+++ b/server/src/main/scala/org/broadinstitute/dsp/workbench/welder/server/BackgroundTask.scala
@@ -46,7 +46,7 @@ class BackgroundTask(
 
   def updateStorageAlg(appConfig: AppConfig.Azure, blockerBound: Semaphore[IO], storageAlgRef: Ref[IO, CloudStorageAlg]): Stream[IO, Unit] = {
     val task = initStorageAlg(appConfig, blockerBound).use(s => storageAlgRef.set(s.cloudStorageAlg))
-    (Stream.sleep_[IO](50 minutes) ++ Stream.eval(task)).repeat
+    (Stream.sleep_[IO](appConfig.miscHttpClientConfig.sasTokenExpiresIn.minus(5 minutes)) ++ Stream.eval(task)).repeat // Refresh sas token a few minutes before it's about to expire
   }
 
   def flushBothCache(

--- a/server/src/test/resources/reference.conf
+++ b/server/src/test/resources/reference.conf
@@ -6,6 +6,7 @@ type = "azure"
 misc-http-client-config = {
   wsm-url = "https://workspace.dsde-dev.broadinstitute.org/"
   workspace-id = "a5a1f1e1-bcb0-49d9-b589-ea4d7c9d6f02"
+  sas-token-expires-in = 8 hours
 }
 workspace-storage-container-resource-id = "9151f3a0-fe5c-49c5-b8a1-dc15cd96b174"
 staging-storage-container-resource-id = "7406737a-7001-45f8-a3bb-aad8577ecd4c"

--- a/server/src/test/scala/org/broadinstitute/dsp/workbench/welder/server/ConfigSpec.scala
+++ b/server/src/test/scala/org/broadinstitute/dsp/workbench/welder/server/ConfigSpec.scala
@@ -72,6 +72,7 @@ class ConfigSpec extends AnyFlatSpec with Matchers {
         |misc-http-client-config = {
         |  wsm-url = "https://workspace.dsde-dev.broadinstitute.org/"
         |  workspace-id = "a5a1f1e1-bcb0-49d9-b589-ea4d7c9d6f02"
+        |  sas-token-expires-in = 8 hours
         |}
         |workspace-storage-container-resource-id = "9151f3a0-fe5c-49c5-b8a1-dc15cd96b174"
         |staging-storage-container-resource-id = "7406737a-7001-45f8-a3bb-aad8577ecd4c"
@@ -106,7 +107,8 @@ class ConfigSpec extends AnyFlatSpec with Matchers {
       30 seconds,
       MiscHttpClientConfig(
         Uri.unsafeFromString("https://workspace.dsde-dev.broadinstitute.org/"),
-        UUID.fromString("a5a1f1e1-bcb0-49d9-b589-ea4d7c9d6f02")
+        UUID.fromString("a5a1f1e1-bcb0-49d9-b589-ea4d7c9d6f02"),
+        8 hours
       ),
       false,
       UUID.fromString("9151f3a0-fe5c-49c5-b8a1-dc15cd96b174"),
@@ -152,7 +154,8 @@ class ConfigSpec extends AnyFlatSpec with Matchers {
       30 seconds,
       MiscHttpClientConfig(
         Uri.unsafeFromString("https://workspace.dsde-dev.broadinstitute.org/"),
-        UUID.fromString("a5a1f1e1-bcb0-49d9-b589-ea4d7c9d6f02")
+        UUID.fromString("a5a1f1e1-bcb0-49d9-b589-ea4d7c9d6f02"),
+        8 hours
       ),
       false,
       UUID.fromString("9151f3a0-fe5c-49c5-b8a1-dc15cd96b174"),


### PR DESCRIPTION
SAS token used to be fixed to expire in one hour, but recently WSM added the ability to specify expiration, and UI is setting it to 8 hours. This PR updates welder to refresh sas token at slightly less than 8 hours cadence