### PR TITLE
IA-3870 Fix .delocalize.json content

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,9 +1,9 @@
 import sbt._
 
 object Dependencies {
-  val circeVersion = "0.14.2"
+  val circeVersion = "0.14.3"
   val http4sVersion = "1.0.0-M35"
-  val grpcCoreVersion = "1.49.2"
+  val grpcCoreVersion = "1.51.0"
   val scalaTestVersion = "3.2.14"
 
   val workbenchLibsHash = "e6ad8a1"
@@ -11,8 +11,8 @@ object Dependencies {
   val workbenchAzureV = s"0.1-$workbenchLibsHash"
 
   val common = List(
-    "com.github.pureconfig" %% "pureconfig" % "0.17.1",
-    "co.fs2" %% "fs2-io" % "3.2.14",
+    "com.github.pureconfig" %% "pureconfig" % "0.17.2",
+    "co.fs2" %% "fs2-io" % "3.4.0",
     "io.circe" %% "circe-core" % circeVersion,
     "io.circe" %% "circe-generic" % circeVersion,
     "io.circe" %% "circe-parser" % circeVersion,
@@ -28,7 +28,7 @@ object Dependencies {
     "org.broadinstitute.dsde.workbench" %% "workbench-azure" % workbenchAzureV % "test" classifier "tests", //for generators/mocks
     "ca.mrvisser" %% "sealerate" % "0.0.6",
     "com.google.cloud" % "google-cloud-nio" % "0.124.21" % "test",
-    "ch.qos.logback" % "logback-classic" % "1.4.3",
+    "ch.qos.logback" % "logback-classic" % "1.4.5",
     "net.logstash.logback" % "logstash-logback-encoder" % "7.2" // for structured logging in logback
   )
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,7 +6,7 @@ object Dependencies {
   val grpcCoreVersion = "1.51.0"
   val scalaTestVersion = "3.2.14"
 
-  val workbenchLibsHash = "e6ad8a1"
+  val workbenchLibsHash = "1a6839f"
   val workbenchGoogle2V = s"0.25-$workbenchLibsHash"
   val workbenchAzureV = s"0.1-$workbenchLibsHash"
 

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -62,7 +62,7 @@ object Settings {
   lazy val commonSettings =
     commonBuildSettings ++ List(
       organization := "org.broadinstitute.dsp.workbench",
-      scalaVersion := "2.13.9",
+      scalaVersion := "2.13.10",
       resolvers ++= commonResolvers,
       scalacOptions ++= commonCompilerSettings,
       scalafmtOnCompile := true,

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.7.2
+sbt.version=1.7.3

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.9.2")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.0")
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.0.4")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.0.6")
 addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.9.11")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.11.0")
 addSbtPlugin("com.github.sbt" % "sbt-git" % "2.0.0")

--- a/server/src/main/scala/org/broadinstitute/dsp/workbench/welder/server/Config.scala
+++ b/server/src/main/scala/org/broadinstitute/dsp/workbench/welder/server/Config.scala
@@ -29,6 +29,8 @@ object Config {
 }
 
 sealed trait AppConfig extends Product with Serializable {
+  def cloudProvider: CloudProvider
+
   def serverPort: Int
   def cleanUpLockInterval: FiniteDuration
   def flushCacheInterval: FiniteDuration
@@ -57,7 +59,9 @@ object AppConfig {
       stagingBucketName: CloudStorageContainer,
       delocalizeDirectoryInterval: FiniteDuration,
       shouldBackgroundSync: Boolean
-  ) extends AppConfig
+  ) extends AppConfig {
+    override def cloudProvider: CloudProvider = CloudProvider.Gcp
+  }
 
   final case class Azure(
       serverPort: Int,
@@ -74,7 +78,9 @@ object AppConfig {
       shouldBackgroundSync: Boolean,
       workspaceStorageContainerResourceId: UUID,
       stagingStorageContainerResourceId: UUID
-  ) extends AppConfig
+  ) extends AppConfig {
+    override def cloudProvider: CloudProvider = CloudProvider.Azure
+  }
 }
 
 final case class EnvironmentVariables(currentUser: WorkbenchEmail)

--- a/server/src/main/scala/org/broadinstitute/dsp/workbench/welder/server/Main.scala
+++ b/server/src/main/scala/org/broadinstitute/dsp/workbench/welder/server/Main.scala
@@ -65,7 +65,7 @@ object Main extends IOApp {
         metadata => List(metadata.localPath -> metadata)
       )
       shutDownSignal <- Stream.eval(SignallingRef[IO, Boolean](false))
-      dispatcher <- Stream.resource(Dispatcher[IO])
+      dispatcher <- Stream.resource(Dispatcher.parallel[IO])
       metadataCacheAlg = new MetadataCacheInterp(metadataCache)
 
       backGroundTaskConfig = BackgroundTaskConfig(

--- a/server/src/main/scala/org/broadinstitute/dsp/workbench/welder/server/Main.scala
+++ b/server/src/main/scala/org/broadinstitute/dsp/workbench/welder/server/Main.scala
@@ -83,7 +83,8 @@ object Main extends IOApp {
         IO(sys.addShutdownHook(backGroundTask.flushBothCacheOnce(appConfig.storageLinksJsonBlobName, appConfig.metadataJsonBlobName).unsafeRunSync()))
       )
     } yield {
-      val storageLinksServiceConfig = StorageLinksServiceConfig(appConfig.objectService.workingDirectory, appConfig.workspaceBucketNameFileName)
+      val storageLinksServiceConfig =
+        StorageLinksServiceConfig(appConfig.cloudProvider, appConfig.objectService.workingDirectory, appConfig.workspaceBucketNameFileName)
       val storageLinksService = StorageLinksService(storageLinksCache, storageAlgRef, metadataCacheAlg, storageLinksServiceConfig, dispatcher)
       val storageLinkAlg = StorageLinksAlg.fromCache(storageLinksCache)
       val objectService = ObjectService(permits, appConfig.objectService, storageAlgRef, storageLinkAlg, metadataCacheAlg)

--- a/server/src/test/scala/org/broadinstitute/dsp/workbench/welder/server/StorageLinksApiServiceSpec.scala
+++ b/server/src/test/scala/org/broadinstitute/dsp/workbench/welder/server/StorageLinksApiServiceSpec.scala
@@ -39,7 +39,7 @@ class StorageLinksApiServiceSpec extends AnyFlatSpec with WelderTestSuite {
       storageLinks,
       googleStorageAlg,
       metadataCacheAlg,
-      StorageLinksServiceConfig(workingDirectory, Paths.get("/tmp/WORKSPACE_BUCKET")),
+      StorageLinksServiceConfig(CloudProvider.Gcp, workingDirectory, Paths.get("/tmp/WORKSPACE_BUCKET")),
       d
     )
   )

--- a/server/src/test/scala/org/broadinstitute/dsp/workbench/welder/server/StorageLinksApiServiceSpec.scala
+++ b/server/src/test/scala/org/broadinstitute/dsp/workbench/welder/server/StorageLinksApiServiceSpec.scala
@@ -34,15 +34,17 @@ class StorageLinksApiServiceSpec extends AnyFlatSpec with WelderTestSuite {
     override def fileToGcsAbsolutePath(localFile: Path, gsPath: CloudBlobPath)(implicit ev: Ask[IO, TraceId]): IO[Unit] = IO.unit
   })
   val metadataCacheAlg = new MetadataCacheInterp(Ref.unsafe[IO, Map[RelativePath, AdaptedGcsMetadataCache]](Map.empty))
-  val storageLinksServiceResource = Dispatcher[IO].map(d =>
-    StorageLinksService(
-      storageLinks,
-      googleStorageAlg,
-      metadataCacheAlg,
-      StorageLinksServiceConfig(CloudProvider.Gcp, workingDirectory, Paths.get("/tmp/WORKSPACE_BUCKET")),
-      d
+  val storageLinksServiceResource = Dispatcher
+    .parallel[IO]
+    .map(d =>
+      StorageLinksService(
+        storageLinks,
+        googleStorageAlg,
+        metadataCacheAlg,
+        StorageLinksServiceConfig(CloudProvider.Gcp, workingDirectory, Paths.get("/tmp/WORKSPACE_BUCKET")),
+        d
+      )
     )
-  )
   val cloudStorageDirectory = CloudStorageDirectory(CloudStorageContainer("foo"), Some(BlobPath("bar")))
   val baseDir = RelativePath(Paths.get("foo"))
   val baseSafeDir = RelativePath(Paths.get("bar"))

--- a/server/src/test/scala/org/broadinstitute/dsp/workbench/welder/server/StorageLinksServiceSpec.scala
+++ b/server/src/test/scala/org/broadinstitute/dsp/workbench/welder/server/StorageLinksServiceSpec.scala
@@ -49,7 +49,7 @@ class StorageLinksServiceSpec extends AnyFlatSpec with WelderTestSuite {
 
   "StorageLinksService" should "create a storage link" in {
     val emptyStorageLinksCache = Ref.unsafe[IO, Map[RelativePath, StorageLink]](Map.empty)
-    val res = Dispatcher[IO].use { d =>
+    val res = Dispatcher.parallel[IO].use { d =>
       val storageLinksService = StorageLinksService(emptyStorageLinksCache, googleStorageAlgRef, metadataCacheAlg, config, d)
 
       val linkToAdd = StorageLink(baseDir, Some(baseSafeDir), cloudStorageDirectory, ".zip".r)
@@ -64,7 +64,7 @@ class StorageLinksServiceSpec extends AnyFlatSpec with WelderTestSuite {
 
   it should "not create duplicate storage links" in {
     val emptyStorageLinksCache = Ref.unsafe[IO, Map[RelativePath, StorageLink]](Map.empty)
-    val res = Dispatcher[IO].use { d =>
+    val res = Dispatcher.parallel[IO].use { d =>
       val storageLinksService = StorageLinksService(emptyStorageLinksCache, googleStorageAlgRef, metadataCacheAlg, config, d)
 
       val linkToAdd = StorageLink(baseDir, Some(baseSafeDir), cloudStorageDirectory, ".zip".r)
@@ -81,7 +81,7 @@ class StorageLinksServiceSpec extends AnyFlatSpec with WelderTestSuite {
 
   it should "initialize directories" in {
     val emptyStorageLinksCache = Ref.unsafe[IO, Map[RelativePath, StorageLink]](Map.empty)
-    val res = Dispatcher[IO].use { d =>
+    val res = Dispatcher.parallel[IO].use { d =>
       val storageLinksService = StorageLinksService(emptyStorageLinksCache, googleStorageAlgRef, metadataCacheAlg, config, d)
 
       val safeAbsolutePath = config.workingDirectory.resolve(baseSafeDir.path.asPath)
@@ -110,7 +110,7 @@ class StorageLinksServiceSpec extends AnyFlatSpec with WelderTestSuite {
   it should "list storage links" in {
     val emptyStorageLinksCache = Ref.unsafe[IO, Map[RelativePath, StorageLink]](Map.empty)
 
-    val res = Dispatcher[IO].use { d =>
+    val res = Dispatcher.parallel[IO].use { d =>
       val storageLinksService = StorageLinksService(emptyStorageLinksCache, googleStorageAlgRef, metadataCacheAlg, config, d)
       for {
         initialListResult <- storageLinksService.getStorageLinks
@@ -128,7 +128,7 @@ class StorageLinksServiceSpec extends AnyFlatSpec with WelderTestSuite {
 
   it should "delete a storage link" in {
     val emptyStorageLinksCache = Ref.unsafe[IO, Map[RelativePath, StorageLink]](Map.empty)
-    val res = Dispatcher[IO].use { d =>
+    val res = Dispatcher.parallel[IO].use { d =>
       val storageLinksService = StorageLinksService(emptyStorageLinksCache, googleStorageAlgRef, metadataCacheAlg, config, d)
 
       for {
@@ -155,7 +155,7 @@ class StorageLinksServiceSpec extends AnyFlatSpec with WelderTestSuite {
   it should "gracefully handle deleting a storage link that doesn't exist" in {
     val emptyStorageLinksCache = Ref.unsafe[IO, Map[RelativePath, StorageLink]](Map.empty)
 
-    val res = Dispatcher[IO].use { d =>
+    val res = Dispatcher.parallel[IO].use { d =>
       val storageLinksService = StorageLinksService(emptyStorageLinksCache, googleStorageAlgRef, metadataCacheAlg, config, d)
 
       for {

--- a/server/src/test/scala/org/broadinstitute/dsp/workbench/welder/server/StorageLinksServiceSpec.scala
+++ b/server/src/test/scala/org/broadinstitute/dsp/workbench/welder/server/StorageLinksServiceSpec.scala
@@ -45,7 +45,7 @@ class StorageLinksServiceSpec extends AnyFlatSpec with WelderTestSuite {
   })
   val emptyMetadataCache = Ref.unsafe[IO, Map[RelativePath, AdaptedGcsMetadataCache]](Map.empty)
   val metadataCacheAlg = new MetadataCacheInterp(emptyMetadataCache)
-  val config = StorageLinksServiceConfig(Paths.get("/tmp"), Paths.get("/tmp/WORKSPACE_BUCKET"))
+  val config = StorageLinksServiceConfig(CloudProvider.Gcp, Paths.get("/tmp"), Paths.get("/tmp/WORKSPACE_BUCKET"))
 
   "StorageLinksService" should "create a storage link" in {
     val emptyStorageLinksCache = Ref.unsafe[IO, Map[RelativePath, StorageLink]](Map.empty)


### PR DESCRIPTION
This file is used in GCP to "inform" notebooks where notebooks live. It's not used today for Azure, but we will need it at some point.

Here's what it looks like before the fix
```
jupyter@vm967041f06:~$ cat .delocalize.json
{"destination":"gs://sc-86520bbe-1d8f-4dd1-9135-df629d162a30/notebooks"}
```

After this PR change (tested in BEE)
```
:~$ cat .delocalize.json 
{"destination":"arhtesting1/analyses"}
```