### PR TITLE
RW-12258 Fix logs

### DIFF
--- a/server/src/main/resources/logback.xml
+++ b/server/src/main/resources/logback.xml
@@ -3,7 +3,7 @@
 <!--  <statusListener class="ch.qos.logback.core.status.NopStatusListener" />-->
   <property name="WORKING_DIRECTORY" value="/work" />
 
-  <appender name="FILE" class="ch.qos.logback.classic.AsyncAppender">
+  <appender name="FILE" class="ch.qos.logback.core.FileAppender">
     <file>${WORKING_DIRECTORY}/.welder.log</file>
 
     <encoder class="net.logstash.logback.encoder.LogstashEncoder">
@@ -33,7 +33,7 @@
 <!--    <appender-ref ref="FILE"/>-->
 <!--  </logger>-->
 
-  <appender name="CONSOLE" class="ch.qos.logback.classic.AsyncAppender">
+  <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
     <param name="Threshold" value="INFO"/>
 
     <encoder class="net.logstash.logback.encoder.LogstashEncoder">
@@ -43,9 +43,17 @@
     </encoder>
   </appender>
 
-  <root level="INFO">
+  <appender name="async-file" class="ch.qos.logback.classic.AsyncAppender">
     <appender-ref ref="FILE" />
-    <appender-ref ref="CONSOLE"/>
+  </appender>
+
+  <appender name="async-console" class="ch.qos.logback.classic.AsyncAppender">
+    <appender-ref ref="CONSOLE" />
+  </appender>
+
+  <root level="INFO">
+    <appender-ref ref="async-file" />
+    <appender-ref ref="async-console"/>
   </root>
 
 </configuration>


### PR DESCRIPTION
In [previous PR](https://github.com/DataBiosphere/welder/pull/267), I attemped to use async appender. But I was doing it wrong. This PR should fix it.

```
[info] 17:03:07,991 |-INFO in ch.qos.logback.classic.AsyncAppender[async-file] - Attaching appender named [FILE] to AsyncAppender.
[info] 17:03:07,992 |-INFO in ch.qos.logback.classic.AsyncAppender[async-file] - Setting discardingThreshold to 51
[info] 17:03:07,992 |-INFO in ch.qos.logback.core.model.processor.AppenderModelHandler - Processing appender named [async-console]
[info] 17:03:07,992 |-INFO in ch.qos.logback.core.model.processor.AppenderModelHandler - About to instantiate appender of type [ch.qos.logback.classic.AsyncAppender]
[info] 17:03:07,992 |-INFO in ch.qos.logback.core.model.processor.AppenderRefModelHandler - Attaching appender named [CONSOLE] to ch.qos.logback.classic.AsyncAppender[async-console]
[info] 17:03:07,992 |-INFO in ch.qos.logback.classic.AsyncAppender[async-console] - Attaching appender named [CONSOLE] to AsyncAppender.
[info] 17:03:07,992 |-INFO in ch.qos.logback.classic.AsyncAppender[async-console] - Setting discardingThreshold to 51
[info] 17:03:07,992 |-INFO in ch.qos.logback.classic.model.processor.RootLoggerModelHandler - Setting level of ROOT logger to INFO
[info] 17:03:07,992 |-INFO in ch.qos.logback.core.model.processor.AppenderRefModelHandler - Attaching appender named [async-file] to Logger[ROOT]
[info] 17:03:07,992 |-INFO in ch.qos.logback.core.model.processor.AppenderRefModelHandler - Attaching appender named [async-console] to Logger[ROOT]
[info] 17:03:07,993 |-INFO in ch.qos.logback.core.model.processor.DefaultProcessor@207b8649 - End of configuration.
```