### PR TITLE
Changing welder UID so that it will be unique

### DIFF
--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -97,7 +97,7 @@ object Settings {
     Docker / packageName := "broad-dsp-gcr-public/welder-server",
     // user, uid, group, and gid are all replicated in the Jupyter container
     Docker / daemonUser := "welder-user",
-    Docker / daemonUserUid := Some("1001"),
+    Docker / daemonUserUid := Some("2001"),
     Docker / daemonGroup := "users",
     Docker / daemonGroupGid := Some("100"),
     dockerEntrypoint := List(entrypoint),


### PR DESCRIPTION
On linux, the user IDs after 1000 are reserved for 'normal' (non-system) users and they normally get assigned sequentially. In order to avoid the case where 1001 is already assigned to a different user, this moves the uid into the 2000s.

Context: A new user was added via the Azure DSVM that bumped the sequence of UIDs back, so 1001 was taken by the leoAdmin user and that caused permission issues for the /work folder welder depends on

Related to:
https://github.com/DataBiosphere/terra-docker/pull/487
https://github.com/DataBiosphere/leonardo/pull/4464