### PR TITLE
ID-1266: Update welder to handle multiple identities assigned to the VM

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsp/workbench/welder/MiscHttpClientInterp.scala
+++ b/core/src/main/scala/org/broadinstitute/dsp/workbench/welder/MiscHttpClientInterp.scala
@@ -1,42 +1,39 @@
 package org.broadinstitute.dsp.workbench.welder
+
 import cats.effect.IO
 import org.broadinstitute.dsde.workbench.DoneCheckable
-import org.broadinstitute.dsde.workbench.google2.streamUntilDoneOrTimeout
-import org.http4s.{AuthScheme, Credentials, Header, Headers, Method, Request, Uri}
-import org.http4s.client.Client
-import org.typelevel.ci.CIString
+import org.broadinstitute.dsde.workbench.google2.{streamFUntilDone, streamUntilDoneOrTimeout}
+import org.broadinstitute.dsp.workbench.welder.MiscHttpClientAlgCodec.{decodePetAccessTokenResp, decodeSasTokenResp}
 import org.http4s.QueryParamEncoder.stringQueryParamEncoder
-import org.broadinstitute.dsp.workbench.welder.MiscHttpClientAlgCodec.decodePetAccessTokenResp
 import org.http4s.circe.CirceEntityCodec.circeEntityDecoder
+import org.http4s.client.Client
 import org.http4s.headers.Authorization
-import org.broadinstitute.dsp.workbench.welder.MiscHttpClientAlgCodec.decodeSasTokenResp
+import org.http4s._
+import org.typelevel.ci.CIString
 
-import java.util.UUID
+import java.nio.charset.StandardCharsets
+import java.util.{Base64, UUID}
 import scala.concurrent.duration.DurationInt
 
 class MiscHttpClientInterp(httpClient: Client[IO], config: MiscHttpClientConfig) extends MiscHttpClientAlg {
-  implicit val doneCheckable: DoneCheckable[Option[PetAccessTokenResp]] = (a: Option[PetAccessTokenResp]) => a.isDefined
+  implicit def doneCheckable[A]: DoneCheckable[Option[A]] = (a: Option[A]) => a.isDefined
 
-  override def getPetAccessToken(): IO[PetAccessTokenResp] = {
-    val uri = (Uri.unsafeFromString("http://169.254.169.254") / "metadata" / "identity" / "oauth2" / "token")
-      .withQueryParams(
-        Map
-          .newBuilder[String, String]
-          .addAll(
-            List("api-version" -> "2018-02-01", "resource" -> "https://management.azure.com/")
-          )
-          .result()
+  override def getPetAccessToken(): IO[PetAccessTokenResp] =
+    getPetManagedIdentityId.flatMap { petManagedIdentityIdOpt =>
+      val queryParams = Map("api-version" -> "2018-02-01", "resource" -> "https://management.azure.com/") ++
+        petManagedIdentityIdOpt.map(mi => Map("msi_res_id" -> mi)).getOrElse(Map.empty)
+      val uri = (Uri.unsafeFromString("http://169.254.169.254") / "metadata" / "identity" / "oauth2" / "token").withQueryParams(queryParams)
+
+      val getPetAccessToken = httpClient.expectOption[PetAccessTokenResp](
+        Request[IO](
+          method = Method.GET,
+          uri = uri.withQueryParams(queryParams),
+          headers = Headers(Header.Raw.apply(CIString("Metadata"), "true"))
+        )
       )
 
-    val getPetAccessToken = httpClient.expectOption[PetAccessTokenResp](
-      Request[IO](
-        method = Method.GET,
-        uri = uri,
-        headers = Headers(Header.Raw.apply(CIString("Metadata"), "true"))
-      )
-    )
-    streamUntilDoneOrTimeout(getPetAccessToken, 10, 10 seconds, "fail to get PET access token").map(_.get)
-  }
+      streamUntilDoneOrTimeout(getPetAccessToken, 10, 10 seconds, "fail to get PET access token").map(_.get)
+    }
 
   override def getSasUrl(petAccessToken: PetAccessToken, storageContainerResourceId: UUID): IO[SasTokenResp] = {
     val uri =
@@ -49,5 +46,22 @@ class MiscHttpClientInterp(httpClient: Client[IO], config: MiscHttpClientConfig)
         headers = Headers(Authorization((Credentials.Token(AuthScheme.Bearer, petAccessToken.value))))
       )
     )
+  }
+
+  private def getPetManagedIdentityId(): IO[Option[String]] = {
+    val uri = (Uri.unsafeFromString("http://169.254.169.254") / "metadata" / "instance" / "compute" / "userData")
+      .withQueryParams(
+        Map("api-version" -> "2021-01-01", "format" -> "text")
+      )
+
+    val getId = httpClient.expectOption[Array[Byte]](
+      Request[IO](
+        method = Method.GET,
+        uri = uri,
+        headers = Headers(Header.Raw.apply(CIString("Metadata"), "true"))
+      )
+    )
+    streamFUntilDone(getId, 5, 2 seconds).compile.lastOrError
+      .map(_.map(b => new String(Base64.getDecoder.decode(b), StandardCharsets.UTF_8)))
   }
 }

--- a/core/src/main/scala/org/broadinstitute/dsp/workbench/welder/MiscHttpClientInterp.scala
+++ b/core/src/main/scala/org/broadinstitute/dsp/workbench/welder/MiscHttpClientInterp.scala
@@ -55,8 +55,8 @@ class MiscHttpClientInterp(httpClient: Client[IO], config: MiscHttpClientConfig)
         Map("api-version" -> "2021-01-01", "format" -> "text")
       )
 
-    // Using `client.run` and testing contentLength in the response to handle empty responses as None.
-    // `client.expectOption[String]` was throwing an exception when the content-length was 0.
+    // Using `client.run` and base64-decoding the entity stream.
+    // I was having issues reading this data with `client.exportOr[String]`.
     httpClient
       .run(
         Request[IO](

--- a/core/src/main/scala/org/broadinstitute/dsp/workbench/welder/MiscHttpClientInterp.scala
+++ b/core/src/main/scala/org/broadinstitute/dsp/workbench/welder/MiscHttpClientInterp.scala
@@ -52,7 +52,7 @@ class MiscHttpClientInterp(httpClient: Client[IO], config: MiscHttpClientConfig)
     )
   }
 
-  private def getPetManagedIdentityId(): IO[Option[String]] = {
+  private[welder] def getPetManagedIdentityId(): IO[Option[String]] = {
     val uri = (Uri.unsafeFromString("http://169.254.169.254") / "metadata" / "instance" / "compute" / "userData")
       .withQueryParams(
         Map("api-version" -> "2021-01-01", "format" -> "text")

--- a/core/src/main/scala/org/broadinstitute/dsp/workbench/welder/MiscHttpClientInterp.scala
+++ b/core/src/main/scala/org/broadinstitute/dsp/workbench/welder/MiscHttpClientInterp.scala
@@ -1,6 +1,8 @@
 package org.broadinstitute.dsp.workbench.welder
 
 import cats.effect.IO
+import cats.syntax.all._
+import fs2._
 import org.broadinstitute.dsde.workbench.DoneCheckable
 import org.broadinstitute.dsde.workbench.google2.streamUntilDoneOrTimeout
 import org.broadinstitute.dsp.workbench.welder.MiscHttpClientAlgCodec.{decodePetAccessTokenResp, decodeSasTokenResp}
@@ -53,14 +55,24 @@ class MiscHttpClientInterp(httpClient: Client[IO], config: MiscHttpClientConfig)
         Map("api-version" -> "2021-01-01", "format" -> "text")
       )
 
-    val getPetId = httpClient.expectOption[Option[String]](
-      Request[IO](
-        method = Method.GET,
-        uri = uri,
-        headers = Headers(Header.Raw.apply(CIString("Metadata"), "true"))
+    // Using `client.run` and testing contentLength in the response to handle empty responses as None.
+    // `client.expectOption[String]` was throwing an exception when the content-length was 0.
+    httpClient
+      .run(
+        Request[IO](
+          method = Method.GET,
+          uri = uri,
+          headers = Headers(Header.Raw.apply(CIString("Metadata"), "true"))
+        )
       )
-    )
-
-    streamUntilDoneOrTimeout(getPetId, 10, 10 seconds, "fail to get PET managed identity id").map(_.flatten)
+      .use { resp =>
+        resp.contentLength.filter(_ > 0).traverse { _ =>
+          resp.bodyText
+            .through(text.base64.decode[IO])
+            .through(text.utf8.decode)
+            .compile
+            .foldMonoid
+        }
+      }
   }
 }

--- a/core/src/main/scala/org/broadinstitute/dsp/workbench/welder/MiscHttpClientInterp.scala
+++ b/core/src/main/scala/org/broadinstitute/dsp/workbench/welder/MiscHttpClientInterp.scala
@@ -55,6 +55,8 @@ class MiscHttpClientInterp(httpClient: Client[IO], config: MiscHttpClientConfig)
         Map("api-version" -> "2021-01-01", "format" -> "text")
       )
 
+    // Using `client.run` and testing contentLength in the response to handle empty responses as None.
+    // `client.expectOption[String]` was throwing an exception when the content-length was 0.
     httpClient
       .run(
         Request[IO](

--- a/core/src/main/scala/org/broadinstitute/dsp/workbench/welder/MiscHttpClientInterp.scala
+++ b/core/src/main/scala/org/broadinstitute/dsp/workbench/welder/MiscHttpClientInterp.scala
@@ -1,18 +1,19 @@
 package org.broadinstitute.dsp.workbench.welder
 
 import cats.effect.IO
+import cats.syntax.all._
+import fs2._
 import org.broadinstitute.dsde.workbench.DoneCheckable
-import org.broadinstitute.dsde.workbench.google2.{streamFUntilDone, streamUntilDoneOrTimeout}
+import org.broadinstitute.dsde.workbench.google2.streamUntilDoneOrTimeout
 import org.broadinstitute.dsp.workbench.welder.MiscHttpClientAlgCodec.{decodePetAccessTokenResp, decodeSasTokenResp}
 import org.http4s.QueryParamEncoder.stringQueryParamEncoder
+import org.http4s._
 import org.http4s.circe.CirceEntityCodec.circeEntityDecoder
 import org.http4s.client.Client
 import org.http4s.headers.Authorization
-import org.http4s._
 import org.typelevel.ci.CIString
 
-import java.nio.charset.StandardCharsets
-import java.util.{Base64, UUID}
+import java.util.UUID
 import scala.concurrent.duration.DurationInt
 
 class MiscHttpClientInterp(httpClient: Client[IO], config: MiscHttpClientConfig) extends MiscHttpClientAlg {
@@ -54,14 +55,22 @@ class MiscHttpClientInterp(httpClient: Client[IO], config: MiscHttpClientConfig)
         Map("api-version" -> "2021-01-01", "format" -> "text")
       )
 
-    val getId = httpClient.expectOption[String](
-      Request[IO](
-        method = Method.GET,
-        uri = uri,
-        headers = Headers(Header.Raw.apply(CIString("Metadata"), "true"))
+    httpClient
+      .run(
+        Request[IO](
+          method = Method.GET,
+          uri = uri,
+          headers = Headers(Header.Raw.apply(CIString("Metadata"), "true"))
+        )
       )
-    )
-    streamFUntilDone(getId, 5, 2 seconds).compile.lastOrError
-      .map(_.map(s => new String(Base64.getDecoder.decode(s), StandardCharsets.UTF_8)))
+      .use { resp =>
+        resp.contentLength.filter(_ > 0).traverse { _ =>
+          resp.bodyText
+            .through(text.base64.decode[IO])
+            .through(text.utf8.decode)
+            .compile
+            .foldMonoid
+        }
+      }
   }
 }


### PR DESCRIPTION
JIRA: https://broadworkbench.atlassian.net/browse/ID-1266

See: https://github.com/DataBiosphere/leonardo/pull/4629

Notebook VMs might have more than 1 managed identity assigned. We are storing the resource ID of the _pet_ managed in the VM `userData`. When welder needs to get a pet token, first consult the userData for the pet resource ID (if not in userData, default to current behavior).

Tested in a BEE with a mutli-identity VM, and a single-identity VM.