### PR TITLE
[CORE-458] Update coursier/cache-action

### DIFF
--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -44,7 +44,7 @@ jobs:
         token: ${{ secrets.CODECOV_TOKEN }}
 
     - name: Setup Cache
-      uses: coursier/cache-action@v5
+      uses: coursier/cache-action@v6
     - name: Cache resources
       run: |
         rm -rf "$HOME/.ivy2/local" || true


### PR DESCRIPTION
Jira: https://broadworkbench.atlassian.net/browse/CORE-458

### What 
- Upgrade of `coursier/cache-action` from `v5` to `v6`

### Why

- The coursier-cache-action has been disabled as per the GitHub changelog (https://github.blog/changelog/2025-03-20-notification-of-upcoming-breaking-changes-in-github-actions/#decommissioned-cache-service-brownouts)