### PR TITLE
DDO-4130 read from google artifact registry

### DIFF
--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -11,7 +11,7 @@ import com.typesafe.sbt.packager.linux.LinuxPlugin.autoImport._
 import sbtbuildinfo.BuildInfoPlugin.autoImport._
 
 object Settings {
-  lazy val artifactory = "https://broadinstitute.jfrog.io/broadinstitute/"
+  lazy val artifactory = "https://us-central1-maven.pkg.dev/dsp-artifact-registry/"
 
   lazy val commonResolvers = List(
     "artifactory-releases" at artifactory + "libs-release",


### PR DESCRIPTION
JIRA ticket https://broadworkbench.atlassian.net/browse/DDO-4130 


**Summary of changes**
Updated the artifact source for this service to read artifacts from Google Artifact Registry instead of JFrog.

**What**
Modified the config to pull artifacts from GAR. No publishing changes were made.

**Why**
This is part of Phase 2 of the artifact migration effort to deprecated JFrog and consolidate artifacts in GAR.

**Testing these changes**
Relied on passing CI checks and tests. Artifact reading-related issues are expected to surface as pipeline failures. For example these jobs [here](https://github.com/DataBiosphere/terra-scientific-pipelines-service/actions/runs/15309876591/job/43071753325?pr=222) and [here](https://github.com/DataBiosphere/leonardo/actions/runs/15324072477/job/43114134405?pr=4858) failed due to access issues (which have since been resolved).